### PR TITLE
TT-642 remove toDate and fromDate fields from Address attributes

### DIFF
--- a/prototypes/prototype-0/stub-verify-hub/src/integration-test/java/uk/gov/ida/stubverifyhub/resources/GenerateAccountCreationSamlResponseTest.java
+++ b/prototypes/prototype-0/stub-verify-hub/src/integration-test/java/uk/gov/ida/stubverifyhub/resources/GenerateAccountCreationSamlResponseTest.java
@@ -90,8 +90,6 @@ public class GenerateAccountCreationSamlResponseTest extends StubVerifyHubAppRul
         assertThat(html).contains("name=\"postCode\"");
         assertThat(html).contains("name=\"internationalPostCode\"");
         assertThat(html).contains("name=\"uprn\"");
-        assertThat(html).contains("name=\"fromDate\"");
-        assertThat(html).contains("name=\"toDate\"");
         assertThat(html).contains("name=\"cycle3\"");
     }
 
@@ -120,8 +118,6 @@ public class GenerateAccountCreationSamlResponseTest extends StubVerifyHubAppRul
             put("postCode", "some-post-code");
             put("internationalPostCode", "some-international-post-code");
             put("uprn", "some-uprn");
-            put("fromDate", "2000/01/01");
-            put("toDate", "207/01/01");
             put("cycle3", "some-cycle-3");
         }};
 
@@ -211,9 +207,7 @@ public class GenerateAccountCreationSamlResponseTest extends StubVerifyHubAppRul
             .put("lines", new JSONArray().put("some-address-line-1").put("some-address-line-2").put("some-address-line-3"))
             .put("postCode", "some-post-code")
             .put("internationalPostCode", "some-international-post-code")
-            .put("uprn", "some-uprn")
-            .put("fromDate", "2000/01/01")
-            .put("toDate", "207/01/01");
+            .put("uprn", "some-uprn");
 
         JSONObject attributes = new JSONObject()
             .put("firstName", "some-first-name")

--- a/prototypes/prototype-0/stub-verify-hub/src/main/java/uk/gov/ida/stubverifyhub/resources/ApplicationResources.java
+++ b/prototypes/prototype-0/stub-verify-hub/src/main/java/uk/gov/ida/stubverifyhub/resources/ApplicationResources.java
@@ -210,9 +210,7 @@ public class ApplicationResources {
                     .put("lines", addressLines)
                     .put("postCode", form.getFirst("postCode"))
                     .put("internationalPostCode", form.getFirst("internationalPostCode"))
-                    .put("uprn", form.getFirst("uprn"))
-                    .put("fromDate", form.getFirst("fromDate"))
-                    .put("toDate", form.getFirst("toDate"));
+                    .put("uprn", form.getFirst("uprn"));
             attributes.put("address", address);
         }
 

--- a/prototypes/prototype-0/stub-verify-hub/src/main/resources/uk/gov/ida/stubverifyhub/views/accountCreationForm.ftl
+++ b/prototypes/prototype-0/stub-verify-hub/src/main/resources/uk/gov/ida/stubverifyhub/views/accountCreationForm.ftl
@@ -94,14 +94,6 @@
                         <input class="form-control" id="uprn" name="uprn"/>
                     </div>
                     <div class="form-group">
-                        <label class="form-label" for="from-date">From Date:</label>
-                        <input class="form-control" id="from-date" name="fromDate" type="date" />
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="to-date">To Date:</label>
-                        <input class="form-control" id="to-date" name="toDate" type="date" />
-                    </div>
-                    <div class="form-group">
                         <div class="multiple-choice">
                             <input type="checkbox" id="address-verified" name="addressVerified" value="true"/>
                             <label for="address-verified">Address verified?</label>


### PR DESCRIPTION
- These attributes are not present in the real SAMLResponse as only the
current address would be returned to the relying parties, therefore
the dates are not relevant.

Author: @sgreensmith