### PR TITLE
BAU: Verify Service Provider - rename response as samlResponse

### DIFF
--- a/prototypes/prototype-0/stub-rp/passport-verify/lib/passport-verify-client.ts
+++ b/prototypes/prototype-0/stub-rp/passport-verify/lib/passport-verify-client.ts
@@ -38,7 +38,7 @@ export default class PassportVerifyClient {
   translateResponse (samlResponse: string, secureToken: string) {
     return this._request('POST', this.verifyServiceProviderHost + '/translate-response',
         { 'Content-Type': 'application/json' },
-        `{ "response": "${samlResponse}", "secureToken": "${secureToken}" }`)
+        `{ "samlResponse": "${samlResponse}", "secureToken": "${secureToken}" }`)
   }
 
 }

--- a/prototypes/prototype-0/stub-rp/passport-verify/test/passport-verify-client-test.ts
+++ b/prototypes/prototype-0/stub-rp/passport-verify/test/passport-verify-client-test.ts
@@ -43,10 +43,10 @@ describe('The passport-verify client', function () {
       let data = ''
       req.on('data', (chunk) => data += chunk)
       req.on('end', () => {
-        if (JSON.parse(data).response === AUTHENTICATION_FAILED_SCENARIO) {
+        if (JSON.parse(data).samlResponse === AUTHENTICATION_FAILED_SCENARIO) {
           res.statusCode = 401
           res.end(JSON.stringify(exampleAuthenticationFailedResponse))
-        } else if (JSON.parse(data).response === SUCCESS_SCENARIO) {
+        } else if (JSON.parse(data).samlResponse === SUCCESS_SCENARIO) {
           res.statusCode = 200
           res.end(JSON.stringify(exampleTranslatedResponse))
         } else {

--- a/prototypes/prototype-0/verify-service-provider/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslateSamlResponseBody.java
+++ b/prototypes/prototype-0/verify-service-provider/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslateSamlResponseBody.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TranslateSamlResponseBody {
-    public final String response;
+    public final String samlResponse;
     public final String secureToken;
 
     @JsonCreator
-    public TranslateSamlResponseBody(@JsonProperty("response") String response,
+    public TranslateSamlResponseBody(@JsonProperty("samlResponse") String samlResponse,
                                      @JsonProperty("secureToken") String secureToken) {
-        this.response = response;
+        this.samlResponse = samlResponse;
         this.secureToken = secureToken;
     }
 }

--- a/prototypes/prototype-0/verify-service-provider/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateSamlResponseResource.java
+++ b/prototypes/prototype-0/verify-service-provider/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateSamlResponseResource.java
@@ -40,7 +40,7 @@ public class TranslateSamlResponseResource {
 
     @POST
     public Response translateResponse(TranslateSamlResponseBody translateSamlResponseBody) {
-        String decodedSamlResponse = new String(Base64.getDecoder().decode(translateSamlResponseBody.response));
+        String decodedSamlResponse = new String(Base64.getDecoder().decode(translateSamlResponseBody.samlResponse));
         String scenario = new JSONObject(decodedSamlResponse).get("scenario").toString();
 
         Response response;
@@ -83,7 +83,7 @@ public class TranslateSamlResponseResource {
         try {
             return Response.ok(convertTranslatedResponseBody(decodedSamlResponse)).build();
         } catch (IOException e) {
-            LOGGER.error("Error during SAML response translation.", e);
+            LOGGER.error("Error during SAML samlResponse translation.", e);
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
     }


### PR DESCRIPTION
The swagger api design documentation describes
TranslateSamlResponseRequestBody to contain a "samlResponse" instead of
"response". This commit renames that particular field to match the
design.

Author: @tunylund