### PR TITLE
TT-725: make startup script work with versioned distributions

### DIFF
--- a/prototypes/prototype-0/verify-service-provider/startup.sh
+++ b/prototypes/prototype-0/verify-service-provider/startup.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 # something about using gradles distZip to:
-./gradlew distZip
+./gradlew installDist 
 
-tar -xf build/distributions/verify-service-provider.zip -C build/distributions/
-
-./build/distributions/verify-service-provider/bin/verify-service-provider server ./configuration/verify-service-provider.yml
+./build/install/verify-service-provider/bin/verify-service-provider server ./configuration/verify-service-provider.yml


### PR DESCRIPTION
The startup script used to use distZip to build the application
distribution and then extract it and run it. As the archive would
contain a changing version number, it would be gnarly to accomodate
the version number in this script.

All of the above can be skipped by using the installDist task
instead.

Author: @tunylund