### PR TITLE
TT-877: Handle NO_MATCH response.

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 import uk.gov.ida.verifyserviceprovider.dto.ErrorBody;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -33,7 +34,7 @@ import static uk.gov.ida.verifyserviceprovider.configuration.MetadataUri.COMPLIA
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
 
-public class ResponseAcceptanceTest {
+public class InvalidSamlAcceptanceTest {
 
     @ClassRule
     public static MockMsaServer msaServer = new MockMsaServer();
@@ -66,29 +67,6 @@ public class ResponseAcceptanceTest {
                 .withEncryptionCertificate(TEST_RP_PUBLIC_ENCRYPTION_CERT)
                 .withExpectedPid("some-expected-pid")
                 .build()
-        );
-    }
-
-    @Test
-    public void shouldHandleASuccessMatchResponse() {
-        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
-        Map<String, String> translateResponseRequestData = ImmutableMap.of(
-            "samlResponse", complianceTool.createSuccessMatchResponseFor(requestResponseBody.getSamlRequest()),
-            "requestId", requestResponseBody.getRequestId()
-        );
-
-        Response response = client
-            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
-            .request()
-            .buildPost(json(translateResponseRequestData))
-            .invoke();
-
-        assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
-        assertThat(response.readEntity(TranslatedResponseBody.class)).isEqualTo(new TranslatedResponseBody(
-            SUCCESS_MATCH,
-            "some-expected-pid",
-            LEVEL_2,
-            null)
         );
     }
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.ida.verifyserviceprovider;
+
+import com.google.common.collect.ImmutableMap;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
+import uk.gov.ida.verifyserviceprovider.dto.ErrorBody;
+import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.Scenario;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
+import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
+import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolInitialisationRequestBuilder.aComplianceToolInitialisationRequest;
+import static uk.gov.ida.verifyserviceprovider.configuration.MetadataUri.COMPLIANCE_TOOL;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
+
+public class NoMatchAcceptanceTest {
+
+    @ClassRule
+    public static MockMsaServer msaServer = new MockMsaServer();
+
+    @ClassRule
+    public static DropwizardAppRule<VerifyServiceProviderConfiguration> application = new DropwizardAppRule<>(
+        VerifyServiceProviderApplication.class,
+        resourceFilePath("verify-service-provider-acceptance-test.yml"),
+        ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
+        ConfigOverride.config("hubSsoLocation", ComplianceToolService.SSO_LOCATION),
+        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+        ConfigOverride.config("verifyHubMetadata.uri", COMPLIANCE_TOOL.getUri().toString()),
+        ConfigOverride.config("msaMetadata.uri", () -> {
+            IdaSamlBootstrap.bootstrap();
+            msaServer.serveDefaultMetadata();
+            return msaServer.getUri();
+        })
+    );
+
+    private static Client client = application.client();
+    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
+    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+
+    @Before
+    public void setUp() {
+        complianceTool.initialiseWith(
+            aComplianceToolInitialisationRequest()
+                .withMatchingServiceSigningPrivateKey(TEST_RP_MS_PRIVATE_SIGNING_KEY)
+                .withMatchingServiceEntityId(MockMsaServer.MSA_ENTITY_ID)
+                .withEncryptionCertificate(TEST_RP_PUBLIC_ENCRYPTION_CERT)
+                .withExpectedPid("some-expected-pid")
+                .build()
+        );
+    }
+
+    @Test
+    public void shouldRespondWithSuccessWhenNoMatch() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+        Map<String, String> translateResponseRequestData = ImmutableMap.of(
+                "samlResponse", complianceTool.createNoMatchResponseFor(requestResponseBody.getSamlRequest()),
+                "requestId", requestResponseBody.getRequestId()
+        );
+
+        Response response = client
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+                .request()
+                .buildPost(json(translateResponseRequestData))
+                .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
+        assertThat(response.readEntity(TranslatedResponseBody.class).getScenario()).isEqualTo(Scenario.NO_MATCH);
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.verifyserviceprovider;
+
+import com.google.common.collect.ImmutableMap;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
+import uk.gov.ida.verifyserviceprovider.dto.ErrorBody;
+import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
+import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
+import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolInitialisationRequestBuilder.aComplianceToolInitialisationRequest;
+import static uk.gov.ida.verifyserviceprovider.configuration.MetadataUri.COMPLIANCE_TOOL;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
+
+public class SuccessMatchAcceptanceTest {
+
+    @ClassRule
+    public static MockMsaServer msaServer = new MockMsaServer();
+
+    @ClassRule
+    public static DropwizardAppRule<VerifyServiceProviderConfiguration> application = new DropwizardAppRule<>(
+        VerifyServiceProviderApplication.class,
+        resourceFilePath("verify-service-provider-acceptance-test.yml"),
+        ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
+        ConfigOverride.config("hubSsoLocation", ComplianceToolService.SSO_LOCATION),
+        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+        ConfigOverride.config("verifyHubMetadata.uri", COMPLIANCE_TOOL.getUri().toString()),
+        ConfigOverride.config("msaMetadata.uri", () -> {
+            IdaSamlBootstrap.bootstrap();
+            msaServer.serveDefaultMetadata();
+            return msaServer.getUri();
+        })
+    );
+
+    private static Client client = application.client();
+    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
+    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+
+    @Before
+    public void setUp() {
+        complianceTool.initialiseWith(
+            aComplianceToolInitialisationRequest()
+                .withMatchingServiceSigningPrivateKey(TEST_RP_MS_PRIVATE_SIGNING_KEY)
+                .withMatchingServiceEntityId(MockMsaServer.MSA_ENTITY_ID)
+                .withEncryptionCertificate(TEST_RP_PUBLIC_ENCRYPTION_CERT)
+                .withExpectedPid("some-expected-pid")
+                .build()
+        );
+    }
+
+    @Test
+    public void shouldHandleASuccessMatchResponse() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+        Map<String, String> translateResponseRequestData = ImmutableMap.of(
+            "samlResponse", complianceTool.createSuccessMatchResponseFor(requestResponseBody.getSamlRequest()),
+            "requestId", requestResponseBody.getRequestId()
+        );
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
+        assertThat(response.readEntity(TranslatedResponseBody.class)).isEqualTo(new TranslatedResponseBody(
+            SUCCESS_MATCH,
+            "some-expected-pid",
+            LEVEL_2,
+            null)
+        );
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
@@ -21,7 +21,7 @@ public class ComplianceToolService {
     public static final String SSO_LOCATION = HOST + "/SAML2/SSO";
 
     private static final int BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID = 1;
-    // public static final int BASIC_NO_MATCH_ID = 2;
+    public static final int BASIC_NO_MATCH_ID = 2;
     // public static final int NO_AUTHENTICATION_CONTEXT_ID = 3;
     // public static final int AUTHENTICATION_FAILED_ID = 4;
     // public static final int REQUESTER_ERROR_ID = 5;
@@ -48,6 +48,10 @@ public class ComplianceToolService {
 
     public String createSuccessMatchResponseFor(String samlRequest) {
         return getExtractedSamlResponse(getResponseUrlById(BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID, samlRequest));
+    }
+
+    public String createNoMatchResponseFor(String samlRequest) {
+        return getExtractedSamlResponse(getResponseUrlById(BASIC_NO_MATCH_ID, samlRequest));
     }
 
     public String createUserAccountCreationResponseFor(String samlRequest) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
@@ -2,15 +2,20 @@ package uk.gov.ida.verifyserviceprovider.services;
 
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+import uk.gov.ida.verifyserviceprovider.dto.Scenario;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class ResponseService {
 
@@ -20,10 +25,10 @@ public class ResponseService {
     private final SamlResponseSignatureValidator responseSignatureValidator;
 
     public ResponseService(
-        StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer,
-        AssertionDecrypter assertionDecrypter,
-        AssertionTranslator assertionTranslator,
-        SamlResponseSignatureValidator responseSignatureValidator) {
+            StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer,
+            AssertionDecrypter assertionDecrypter,
+            AssertionTranslator assertionTranslator,
+            SamlResponseSignatureValidator responseSignatureValidator) {
         this.stringToOpenSamlObjectTransformer = stringToOpenSamlObjectTransformer;
         this.assertionDecrypter = assertionDecrypter;
         this.assertionTranslator = assertionTranslator;
@@ -35,13 +40,35 @@ public class ResponseService {
 
         ValidatedResponse validatedResponse = responseSignatureValidator.validate(response, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
-        if (!expectedInResponseTo.equals(response.getInResponseTo())) {
+        if (!expectedInResponseTo.equals(validatedResponse.getInResponseTo())) {
             throw new SamlResponseValidationException(
-                "Expected InResponseTo to be " + expectedInResponseTo + ", but was " + response.getInResponseTo());
+                    "Expected InResponseTo to be " + expectedInResponseTo + ", but was " + response.getInResponseTo());
         }
 
-        List<Assertion> assertions = assertionDecrypter.decryptAssertions(validatedResponse);
+        StatusCode statusCode = validatedResponse.getStatus().getStatusCode();
 
-        return assertionTranslator.translate(assertions, expectedInResponseTo);
+        switch (statusCode.getValue()) {
+            case StatusCode.RESPONDER:
+                return translateNonSuccessResponse(statusCode);
+            case StatusCode.SUCCESS:
+                List<Assertion> assertions = assertionDecrypter.decryptAssertions(validatedResponse);
+
+                return assertionTranslator.translate(assertions, expectedInResponseTo);
+            default:
+                throw new SamlResponseValidationException(String.format("Unknown SAML status: %s", statusCode.getValue()));
+        }
+    }
+
+    private TranslatedResponseBody translateNonSuccessResponse(StatusCode statusCode) {
+        Optional.ofNullable(statusCode.getStatusCode())
+                .orElseThrow(() -> new SamlResponseValidationException("Missing status code for non-Success response"));
+        String subStatus = statusCode.getStatusCode().getValue();
+
+        switch (subStatus) {
+            case SamlStatusCode.NO_MATCH:
+                return new TranslatedResponseBody(Scenario.NO_MATCH, null, null, null);
+            default:
+                throw new SamlResponseValidationException(String.format("Unknown SAML sub-status: %s", subStatus));
+        }
     }
 }

--- a/src/test/java/common/uk/gov/ida/verifyserviceprovider/utils/SamlResponseHelper.java
+++ b/src/test/java/common/uk/gov/ida/verifyserviceprovider/utils/SamlResponseHelper.java
@@ -1,0 +1,23 @@
+package common.uk.gov.ida.verifyserviceprovider.utils;
+
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.Verified;
+
+public class SamlResponseHelper {
+
+    public static Attribute createVerifiedAttribute(String name, boolean value) {
+        Attribute attribute = new OpenSamlXmlObjectFactory().createAttribute();
+        attribute.setName(name);
+
+        XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+        Verified verifiedValue = (Verified) builderFactory.getBuilder(Verified.TYPE_NAME).buildObject(Verified.DEFAULT_ELEMENT_NAME, Verified.TYPE_NAME);
+        verifiedValue.setValue(value);
+
+        attribute.getAttributeValues().add(verifiedValue);
+
+        return attribute;
+    }
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/AttributeTranslationServiceTests.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/AttributeTranslationServiceTests.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 
+import static common.uk.gov.ida.verifyserviceprovider.utils.SamlResponseHelper.createVerifiedAttribute;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
 
@@ -231,18 +232,5 @@ public class AttributeTranslationServiceTests {
             .build();
 
         AttributeTranslationService.translateAttributes(attributeStatement);
-    }
-
-    private Attribute createVerifiedAttribute(String name, boolean value) {
-        Attribute attribute = new OpenSamlXmlObjectFactory().createAttribute();
-        attribute.setName(name);
-
-        XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-        Verified verifiedValue = (Verified) builderFactory.getBuilder(Verified.TYPE_NAME).buildObject(Verified.DEFAULT_ELEMENT_NAME, Verified.TYPE_NAME);
-        verifiedValue.setValue(value);
-
-        attribute.getAttributeValues().add(verifiedValue);
-
-        return attribute;
     }
 }


### PR DESCRIPTION
Handles no match response and added test of user account creation. Refactored acceptance tests
into separate files. Added switch statements for other response status cases.

Authors: @andy-paine @IreneLau-GDS