### PR TITLE
BAU: Added dev configuration file to mirror dev-manifest.yml

### DIFF
--- a/configuration/verify-service-provider-dev.yml
+++ b/configuration/verify-service-provider-dev.yml
@@ -1,0 +1,54 @@
+# This is an example configuration file to show how to configure
+# the application using a YAML file.
+
+# Dropwizard server connector configuration
+# see: http://www.dropwizard.io/1.1.2/docs/manual/configuration.html#servers
+server:
+  type: simple
+  applicationContextPath: /
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: ${PORT:-50400}
+
+# Logging configuration
+# see: http://www.dropwizard.io/1.1.2/docs/manual/configuration.html#logging
+logging:
+  level: ${LOG_LEVEL:-INFO}
+  loggers:
+    "uk.gov": DEBUG
+  appenders:
+    - type: console
+    - type: file
+      currentLogFilename: logs/verify-service-provider.log
+      archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
+
+# Entity ID that uniquely identifies your service
+serviceEntityId: ${SERVICE_ENTITY_ID:-http://verify-service-provider-dev-service}
+
+# Location where Verify Hub authentication flow begins
+hubSsoLocation: ${HUB_SSO_LOCATION:-https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/SSO}
+
+# Location of hub metadata
+# Verify Service Provider consumes the metadata and
+# Hub Public certificates from the metadata to identify the hub
+verifyHubMetadata:
+  uri: ${HUB_METADATA_URL:-https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/metadata/federation}
+
+# Location of Matching Service Metadata
+# Verify Service Provider consumes the metadata and uses
+# public certificates from it to identify the msa
+msaMetadata:
+  uri: ${MSA_METADATA_URL:-https://verify-service-provider-stub-msa-metadata.cloudapps.digital/metadata.xml}
+  expectedEntityId: ${MSA_ENTITY_ID:-https://verify-service-provider-stub-msa}
+
+# Private key that is used to sign an AuthnRequest
+samlSigningKey: ${SAML_SIGNING_KEY:-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9JoMp7LFUL6WVXGC+J9QZ8GLQFAXbhSfsmz+a0u3oNJ9O2I20vCRsktv9jWERm1l57mPPlakT43d8YvcIUXXDL57NU85IQxw/kAnfvp0nhCQyCVoNU0Tj1AfEznx0t1F1tJj8LAZNzJHxkM4cLqxx2B0+MOgzcSHIDv0Ro3JxqXEtC/2bTViACMLNoT5p+87nWXwDrDEOhp0xkbrw9rP2Tg+YnKD/Ny/dWuy9MvnAyz2pfVRbUXthAtMQRUuRLTigYizFYQWG1MO/ZWyJ/tbY0kupOOgqtMsoefs35oQwYyyQlVzuAUWbQTBMqQi38+sTUFdbt/2I0y8Gzf0+eSTJAgMBAAECggEADEEwgkjZfFDR84lWoztFXKDcZgrGDmDkI0ozpr4/t6mhIKSbGbiOy5IAOr8sKM3d0C6HvO0/VRCJrz9iLeHJNWoiab8iQEBI1j1oxlw9JlBDYBKHCRH6BqC4GCIgohc2ad/XgY8AoY29bt8o216SwZV035CfmqWbwLBn6Pqj8YUiGl1w+qNXM6zsneKx0TOgu71hbn0wZSboYQQupuPhMWJvHq+AolDAZJapmdI35sPjFvv6DesN4Yzcub21GloyqHMqDAA7FUV46TJWDpH/uoGiz8CEDvvrzt7gOVFAguNQf5BGKJ0LIgRxZbCICcMIE7jdHRAnWaqI3kSADycs2QKBgQD5FR63D22mfqzz+YGZ4uRKxkggexa1tkbKdTGilnGvU99WuZ1o/IGLcFRpoGn8JesZV2M+BF9Gs7HnWGB1q0QV5J63b5K2M1PfB5qgeS4aQR7ZUhWOzMch7Y42RF0GHD/ilaZaBE4fgNs2XwW5LGGsXnpar9TJpNjeu22fKzHimwKBgQDCZ0x0ua0uJUj6rCGXB05iw/hTdlaarQ/b56GXoC9l/X74eNMgRDlHA1SExX4+yBt6XX464giGo0NHNI09mMduirJOMhilF2tMQmOAZ6HumsD+QTt6MihWdjUEuohMByAR+ewiVPJ4hMdxiikODOS78qOIT+0Qz7oClwVOinYqawKBgEK0fEBMGnJfNFQ2OpYKpFa+GSzRqfhJ81Ve40cGgTWSAZrJJLWsAclk8MZE1n1XbkmgFIzUQOu/TeKF0XdRwW8XhcXcVG8E+e4drDRTn5waWneauvk+MAoPA2nXDw6G3DkDGMS8qGtZZ9t8wRyhHRs7RgspUZQa2JV1nlrlB3wHAoGAcPUUt74romSHwx/BZMAaC8lSwSxBph5o2J3+htvMrrZc0INkKZt6rIiC06LteA1N6gvpDM3JpnG25ejjKKddOh3c/RKev06cSfNJXZLZxIqnGRVOOfJq/dIxfE3mZEa/m7JcQpaZTO3Z9V8R+9gCEDMsUkget2X77wVRUBGkF4ECgYEApXL4Hgu6rktdFUi1SVh2lUsTFcW1BzMlFKVDybH61DkNZoTUhHIXQTczoELwGg7Aw6w6y2bLlR2FEnOUk7NLFKSsXOxJZ4LZwFyEsPfxIN3P5gj+e0R2WF1UZyiqnqQOqbCFaXoXiPgyAzEMJRI9cYIT36++r5k22CqoIAOKeuk=}
+
+
+# Private key used to decrypt Assertions in the Response
+samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDAKyE+bqP5IGMLqLiRJ2UUfQfyksQ57/yC+tRK03R8Kw7t9q2DIihcw5DC1OS4Bb1wEvQ9g+QoF+kVqRmYzJlk+9qSof5CuEBoIVVrS4maVDgMRXO5REXTBuTPhdmo6jKiYtABO2/3OlvZwd9MJLzt6MhDT/A4Id2Ik4I8FyDEaMAvzO0QS4ADKmClOtE6hOG3FOHgWp056qJLTc0BlzGLusxtDw7bS0TgxQiQGYVTbIH5SBbfds5JrWKfkzAR28VPhu4/xH6sRnhwPf4rVN4OlPiyxgIJ2jhQL9b365IiJM4vVS2YFXyQCdS8ODgs0F7mYn0zXNm9CVeuAIs13+ehAgMBAAECggEAe+aTDZzqjkLqeWb0cWp0Cqy+xhEJAc4RAiZVYFVMIo7klltY7lbErWLOYEBBo8DXrn4aCduS7KLV/shDn7gzIuAbwjU+KaiApmLvnzlZ5C5u4MKa5ZX2ayRjvMWxW+58bSTGtjSrcTyoYhNVNNPvGHnhPT06RgbXvipVawcCcn9zvJbvta6EXwElvL8EaTGg2cIrmiZkXn1B0Y1ux4wOEHgTXrfHpXxC0K2kcLVbZdZvR+M06+PjsJTR5kciQhdXckO9wAX8SN6vDPZsq9Ldzf76bgTgygbW3+uhFlMWPIzqDS44paMqGiIl026b8w8gvjLXHiWIzgycoJ9JKDhjUQKBgQD3y3Yr+KgUe1f2EBnZrRDqhyeBNNPjGoTCKcqFLdZEhA7gc/xsltRoLPPGB84uDiZFW2dwJ/urTd8UhpjfHqBNXRZyUSy1zSy/C4a/FFftTCTnhGbLB6wtcTy5jkpI9J4fX25Qvzhtz9khbGcYaNd3FlPY057NNobyfGKKBPI1BQKBgQDGiCDO115wKw0+2OHITSeFDLWW1Kaup5s8jDgGyKGcsp9EQgvEdbIkbDpa7Xvcx5MWaowf9Trb5ylg/9XDJo/cDBVs6h4INqhPdqbqQf/0KksJBscvZ94BO7znXxlwlY+cAAKl1lN+9SO93LKTNhz0W5kZn5OMleOlxojYA8oq7QKBgHPZe/Yy2uI4iHdSL8PFVhNP/Pg7apTS4R6lyzlYpMSDuTDXCTz7h3LtEUuUeqCtnNbwVPvqtY7xaUp/YxltiCSjUMtBiFW3BySKjwTmzfTzlI1pKWXiwGy+dFWMYM6bDxI726eEvy0X77vgopKW8aWLmsfUqHno9E6KOMeuaE7BAoGBAIRGVJ2bjxdrB8M025IKHeee5SoeewPpNhvsTLPwXwU5WbYvzwlRZaSw21yT2C/sZMrNqJjuWg4EAWTYcAM7ISR6hJfxkJrmV9PB+UohOTjkKORVuMaUDK2DsMPzb868R1eoBhuaJj1zdSHd9rjwl/ATS3lwAe3sPCXKloheVgetAoGBAMdN0h/Dga+ctf7WENVfIblFXuD2Zwzrhkpnsa/+ZgTngn6VzLFBJOKlRM3rMlGBZAawu3RIviGNAyd6tJDsCsO4Rs5ziRrRy1OvcoX7THFNnj/DaWOdpFuhF+l/GFCCaNPl0BxCcCtIPpNoHq/+eSWPJq1ON/kTAVsBB5/Ztzpz}
+
+# Secondary private key used to decrypt Assertions in the Response
+# This only needs to be set if during key rotations (for example if your primary encryption certificate is about to expire)
+samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}


### PR DESCRIPTION
To test integration of local VSP changes with the stub, it is
useful to be able to run the VSP with the same config as on PaaS
This configuration file uses the same 100 year keys as PaaS

Authors: @andy-paine @IreneLau-GDS