### PR TITLE
TT-976: Add level of assurance check to /translate-response endpoint

### DIFF
--- a/architecture-decisions/verify-service-provider-api.swagger.yml
+++ b/architecture-decisions/verify-service-provider-api.swagger.yml
@@ -125,6 +125,7 @@ definitions:
     required:
       - samlResponse
       - requestId
+      - levelOfAssurance
     properties:
       samlResponse:
         description: A SAML Authn response as a base64 string.
@@ -137,6 +138,9 @@ definitions:
           same browser.
         type: string
         format: byte
+      levelOfAssurance:
+        description: The minimum level of assurance required
+        $ref: '#/definitions/ReceivedLevelOfAssurance'
   TranslatedResponseBody:
     type: object
     required:

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnFailedResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnFailedResponseAcceptanceTest.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.AUTHENTICATION_FAILED_ID;
-import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.BASIC_NO_MATCH_ID;
 
 public class AuthnFailedResponseAcceptanceTest {
 
@@ -44,7 +44,8 @@ public class AuthnFailedResponseAcceptanceTest {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), AUTHENTICATION_FAILED_ID),
-            "requestId", requestResponseBody.getRequestId()
+            "requestId", requestResponseBody.getRequestId(),
+            "levelOfAssurance", LEVEL_2.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ErrorResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ErrorResponseAcceptanceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.REQUESTER_ERROR_ID;
 
 public class ErrorResponseAcceptanceTest {
@@ -43,7 +44,8 @@ public class ErrorResponseAcceptanceTest {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), REQUESTER_ERROR_ID),
-            "requestId", requestResponseBody.getRequestId()
+            "requestId", requestResponseBody.getRequestId(),
+            "levelOfAssurance", LEVEL_2.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.BASIC_SUCCESSFUL_MATCH_WITH_ASSERTIONS_SIGNED_BY_HUB_ID;
 
 public class InvalidSamlAcceptanceTest {
@@ -42,7 +43,8 @@ public class InvalidSamlAcceptanceTest {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_ASSERTIONS_SIGNED_BY_HUB_ID),
-            "requestId", requestResponseBody.getRequestId()
+            "requestId", requestResponseBody.getRequestId(),
+            "levelOfAssurance", LEVEL_2.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoAuthnContextResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoAuthnContextResponseAcceptanceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.NO_AUTHENTICATION_CONTEXT_ID;
 
 public class NoAuthnContextResponseAcceptanceTest {
@@ -43,7 +44,8 @@ public class NoAuthnContextResponseAcceptanceTest {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), NO_AUTHENTICATION_CONTEXT_ID),
-            "requestId", requestResponseBody.getRequestId()
+            "requestId", requestResponseBody.getRequestId(),
+            "levelOfAssurance", LEVEL_2.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.BASIC_NO_MATCH_ID;
 
 public class NoMatchAcceptanceTest {
@@ -43,7 +44,8 @@ public class NoMatchAcceptanceTest {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_NO_MATCH_ID),
-            "requestId", requestResponseBody.getRequestId()
+            "requestId", requestResponseBody.getRequestId(),
+            "levelOfAssurance", LEVEL_2.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
@@ -30,8 +30,8 @@ public class ComplianceToolService {
     public static final int AUTHENTICATION_FAILED_ID = 4;
     public static final int REQUESTER_ERROR_ID = 5;
     public static final int ACCOUNT_CREATION_LOA2_ID = 6;
-    // public static final int BASIC_SUCCESSFUL_MATCH_WITH_LOA1_ID = 7;
-    // public static final int ACCOUNT_CREATION_LOA1_ID = 8;
+    public static final int BASIC_SUCCESSFUL_MATCH_WITH_LOA1_ID = 7;
+    public static final int ACCOUNT_CREATION_LOA1_ID = 8;
     public static final int BASIC_SUCCESSFUL_MATCH_WITH_ASSERTIONS_SIGNED_BY_HUB_ID = 9;
 
     private final Client client;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/LevelOfAssurance.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/LevelOfAssurance.java
@@ -3,8 +3,15 @@ package uk.gov.ida.verifyserviceprovider.dto;
 import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
 
 public enum LevelOfAssurance {
-    LEVEL_1,
-    LEVEL_2;
+
+    LEVEL_1(1),
+    LEVEL_2(2);
+
+    private final int value;
+
+    private LevelOfAssurance(int value) {
+        this.value = value;
+    }
 
     public static LevelOfAssurance fromSamlValue(String samlValue) {
         switch (samlValue) {
@@ -15,5 +22,9 @@ public enum LevelOfAssurance {
             default:
                 throw new RuntimeException("Unknown level of assurance: " + samlValue);
         }
+    }
+
+    public boolean isGreaterThan(LevelOfAssurance target) {
+        return value > target.value;
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslateSamlResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslateSamlResponseBody.java
@@ -8,14 +8,17 @@ import javax.validation.constraints.NotNull;
 public class TranslateSamlResponseBody {
     private final String samlResponse;
     private final String requestId;
+    private final LevelOfAssurance levelOfAssurance;
 
     @JsonCreator
     public TranslateSamlResponseBody(
         @JsonProperty(value = "samlResponse") String samlResponse,
-        @JsonProperty(value = "requestId") String requestId
+        @JsonProperty(value = "requestId") String requestId,
+        @JsonProperty(value = "levelOfAssurance") LevelOfAssurance levelOfAssurance
     ) {
         this.samlResponse = samlResponse;
         this.requestId = requestId;
+        this.levelOfAssurance = levelOfAssurance;
     }
 
     @NotNull
@@ -26,5 +29,10 @@ public class TranslateSamlResponseBody {
     @NotNull
     public String getRequestId() {
         return requestId;
+    }
+
+    @NotNull
+    public LevelOfAssurance getLevelOfAssurance() {
+        return levelOfAssurance;
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateSamlResponseResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateSamlResponseResource.java
@@ -35,7 +35,8 @@ public class TranslateSamlResponseResource {
             return Response
                 .ok(responseService.convertTranslatedResponseBody(
                     translateSamlResponseBody.getSamlResponse(),
-                    translateSamlResponseBody.getRequestId())
+                    translateSamlResponseBody.getRequestId(),
+                    translateSamlResponseBody.getLevelOfAssurance())
                 )
                 .build();
         } catch (SamlResponseValidationException | SamlTransformationErrorException e) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
@@ -9,11 +9,11 @@ import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.Scenario;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,7 +35,7 @@ public class ResponseService {
         this.responseSignatureValidator = responseSignatureValidator;
     }
 
-    public TranslatedResponseBody convertTranslatedResponseBody(String decodedSamlResponse, String expectedInResponseTo) {
+    public TranslatedResponseBody convertTranslatedResponseBody(String decodedSamlResponse, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance) {
         Response response = stringToOpenSamlObjectTransformer.apply(decodedSamlResponse);
 
         ValidatedResponse validatedResponse = responseSignatureValidator.validate(response, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -52,7 +52,7 @@ public class ResponseService {
                 return translateNonSuccessResponse(statusCode);
             case StatusCode.SUCCESS:
                 List<Assertion> assertions = assertionDecrypter.decryptAssertions(validatedResponse);
-                return assertionTranslator.translate(assertions, expectedInResponseTo);
+                return assertionTranslator.translate(assertions, expectedInResponseTo, expectedLevelOfAssurance);
             default:
                 throw new SamlResponseValidationException(String.format("Unknown SAML status: %s", statusCode.getValue()));
         }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
@@ -9,8 +9,6 @@ import org.junit.rules.ExpectedException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
@@ -119,7 +117,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result).isEqualTo(new TranslatedResponseBody(
@@ -142,7 +141,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result.getScenario()).isEqualTo(ACCOUNT_CREATION);
@@ -165,7 +165,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result.getScenario()).isEqualTo(NO_MATCH);
@@ -187,7 +188,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
             responseToBase64StringTransformer.apply(response),
-            response.getInResponseTo()
+            response.getInResponseTo(),
+            LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result.getScenario()).isEqualTo(REQUEST_ERROR);
@@ -209,7 +211,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
             responseToBase64StringTransformer.apply(response),
-            response.getInResponseTo()
+            response.getInResponseTo(),
+            LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result.getScenario()).isEqualTo(CANCELLATION);
@@ -231,7 +234,8 @@ public class ResponseServiceTest {
 
         TranslatedResponseBody result = responseService.convertTranslatedResponseBody(
             responseToBase64StringTransformer.apply(response),
-            response.getInResponseTo()
+            response.getInResponseTo(),
+            LevelOfAssurance.LEVEL_2
         );
 
         assertThat(result.getScenario()).isEqualTo(AUTHENTICATION_FAILED);
@@ -255,7 +259,8 @@ public class ResponseServiceTest {
 
         responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
     }
 
@@ -278,7 +283,8 @@ public class ResponseServiceTest {
 
         responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
     }
 
@@ -297,7 +303,8 @@ public class ResponseServiceTest {
 
         responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
     }
 
@@ -316,7 +323,8 @@ public class ResponseServiceTest {
 
         responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo()
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2
         );
     }
 
@@ -335,7 +343,8 @@ public class ResponseServiceTest {
 
         responseService.convertTranslatedResponseBody(
                 responseToBase64StringTransformer.apply(response),
-                "some-incorrect-request-id"
+                "some-incorrect-request-id",
+                LevelOfAssurance.LEVEL_2
         );
     }
 


### PR DESCRIPTION
Added a minimum level of assurance field to /translate-response request
Validated that SAML level of assurance was greater than or equal to
requested level of assurance

Authors: @IreneLau-GDS @tunylund @andy-paine