### PR TITLE
TT-1001: Add acceptance test for secondary key for cert rotations

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SecondaryEncryptionKeyAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SecondaryEncryptionKeyAcceptanceTest.java
@@ -1,0 +1,83 @@
+package uk.gov.ida.verifyserviceprovider;
+
+import com.google.common.collect.ImmutableMap;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import sun.security.rsa.RSAKeyPairGenerator;
+import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
+import uk.gov.ida.verifyserviceprovider.rules.VerifyServiceProviderAppRule;
+import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
+import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
+import uk.gov.ida.verifyserviceprovider.utils.Crypto;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Map;
+
+import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolInitialisationRequestBuilder.aComplianceToolInitialisationRequest;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_1;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
+import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.BASIC_SUCCESSFUL_MATCH_WITH_LOA1_ID;
+import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID;
+
+public class SecondaryEncryptionKeyAcceptanceTest {
+
+    @ClassRule
+    public static MockMsaServer msaServer = new MockMsaServer();
+
+    @ClassRule
+    public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer, TEST_RP_MS_PRIVATE_ENCRYPTION_KEY);
+
+    private static Client client = application.client();
+    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
+    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+
+    @Before
+    public void setUp() {
+        complianceTool.initialiseWith(
+                aComplianceToolInitialisationRequest()
+                .withEncryptionCertificate(TEST_RP_MS_PUBLIC_ENCRYPTION_CERT)
+                .build()
+        );
+    }
+
+    @Test
+    public void shouldHandleASuccessMatchResponseSignedWithSecondaryKey() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+        Map<String, String> translateResponseRequestData = ImmutableMap.of(
+                "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID),
+                "requestId", requestResponseBody.getRequestId(),
+                "levelOfAssurance", LEVEL_2.name()
+        );
+
+        Response response = client
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+                .request()
+                .buildPost(json(translateResponseRequestData))
+                .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
+        assertThat(response.readEntity(TranslatedResponseBody.class)).isEqualTo(new TranslatedResponseBody(
+                SUCCESS_MATCH,
+                "default-expected-pid",
+                LEVEL_2,
+                null)
+        );
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolInitialisationRequestBuilder.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolInitialisationRequestBuilder.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.verifyserviceprovider.builders;
 
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+
 import javax.ws.rs.client.Entity;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +18,7 @@ public class ComplianceToolInitialisationRequestBuilder {
     private String signingCertificate = TEST_RP_PUBLIC_SIGNING_CERT;
     private String encryptionCertificate = TEST_RP_PUBLIC_ENCRYPTION_CERT;
     private String expectedPID = "default-expected-pid";
-    private String matchingServiceEntityId = "http://verify-service-provider-acceptance-test/msa";
+    private String matchingServiceEntityId = MockMsaServer.MSA_ENTITY_ID;
     private String matchingServiceSigningPrivateKey = TEST_RP_MS_PRIVATE_SIGNING_KEY;
     private List<String> userAccountCreationAttributes = emptyList();
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
@@ -15,13 +15,14 @@ import static uk.gov.ida.verifyserviceprovider.configuration.MetadataUri.COMPLIA
 
 public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServiceProviderConfiguration> {
 
-    public VerifyServiceProviderAppRule(MockMsaServer msaServer) {
+    public VerifyServiceProviderAppRule(MockMsaServer msaServer, String secondaryEncryptionKey) {
         super(
             VerifyServiceProviderApplication.class,
             resourceFilePath("verify-service-provider-acceptance-test.yml"),
             ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
             ConfigOverride.config("hubSsoLocation", ComplianceToolService.SSO_LOCATION),
             ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+            ConfigOverride.config("samlSecondaryEncryptionKey", secondaryEncryptionKey),
             ConfigOverride.config("verifyHubMetadata.uri", COMPLIANCE_TOOL.getUri().toString()),
             ConfigOverride.config("msaMetadata.uri", () -> {
                 IdaSamlBootstrap.bootstrap();
@@ -29,5 +30,9 @@ public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServic
                 return msaServer.getUri();
             })
         );
+    }
+
+    public VerifyServiceProviderAppRule(MockMsaServer msaServer) {
+        this(msaServer, TEST_RP_PRIVATE_ENCRYPTION_KEY);
     }
 }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/ComplianceToolService.java
@@ -57,9 +57,6 @@ public class ComplianceToolService {
     public void initialiseWithPid(String pid) {
         initialiseWith(
             aComplianceToolInitialisationRequest()
-                .withMatchingServiceSigningPrivateKey(TEST_RP_MS_PRIVATE_SIGNING_KEY)
-                .withMatchingServiceEntityId(MockMsaServer.MSA_ENTITY_ID)
-                .withEncryptionCertificate(TEST_RP_PUBLIC_ENCRYPTION_CERT)
                 .withExpectedPid(pid)
                 .build()
         );


### PR DESCRIPTION
Added a test and refactored builder slightly to test that we
can decrypt assertions with our secondary key for when we need to rotate
certs

Authors: @andy-paine