### PR TITLE
TT-1000: Remove distZip from pre-commit

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -6,4 +6,4 @@ function cleanup {
 }
 trap cleanup EXIT
 cd "$(dirname "$0")"
-./gradlew clean test testAcceptance distZip
+./gradlew clean test testAcceptance


### PR DESCRIPTION
distZip has been added as a separate step on jenkins
It is not needed in pre-commit anymore

Authors: @andy-paine