### PR TITLE
TT-1000: Add semver to output version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ repositories {
 }
 
 project.ext {
+    version_number = '0.1'
     openSamlVersion = '3.3.0'
     samlMetaDataBindingVersion = '46'
 }
@@ -45,6 +46,8 @@ sourceSets {
         compileClasspath += sourceSets.test.output
     }
 }
+
+version = "$version_number-" + System.getenv('BUILD_NUMBER')
 
 distributions {
     main {


### PR DESCRIPTION
Fetch BUILD_NUMBER using gradle instead of command line args

Authors: @andy-paine