### PR TITLE
bau: Tidy shell scripts a bit

### DIFF
--- a/dev-deployment.sh
+++ b/dev-deployment.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -e
-CURRENT_DIR="$PWD"
+
+ROOT_DIR="$(dirname "$0")"
+cd "$ROOT_DIR"
+
 function cleanup {
-  rm -rf "$CURRENT_DIR/work"
+  rm -rf "$ROOT_DIR/work"
 }
 trap cleanup EXIT
-cd "$(dirname "$0")"
 
 
 cfLogin() {
@@ -19,7 +21,7 @@ cfLogin() {
 
     # CloudFoundry will cache credentials in ~/.cf/config.json by default.
     # Create a dedicated work area to avoid contaminating the user's credential cache
-    export CF_HOME="$CURRENT_DIR/work"
+    export CF_HOME="$ROOT_DIR/work"
     rm -rf "$CF_HOME"
     mkdir -p "$CF_HOME"
     echo "Authenticating to CloudFoundry at '$CF_API' ($CF_ORG/$CF_SPACE) as '$CF_USER'" >&2

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
-CURRENT_DIR=$PWD
-function cleanup {
-  cd "$CURRENT_DIR"
-}
-trap cleanup EXIT
+
 cd "$(dirname "$0")"
 ./gradlew clean test testAcceptance
+

--- a/scripts/init-compliance-tool.sh
+++ b/scripts/init-compliance-tool.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -e
 
-cd "$(dirname $0)"
+cd "$(dirname "$0")"
 curl https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/service-test-data --data @compliance-tool-init.json --header 'Content-Type: application/json'
 echo
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
-# something about using gradles distZip to:
-./gradlew installDist 
+cd "$(dirname "$0")"
+
+./gradlew installDist
 
 ./build/install/verify-service-provider/bin/verify-service-provider server ./configuration/verify-service-provider.yml


### PR DESCRIPTION
The cleanup - cd current directory is not necessary for scripts. They
run in subshells, so they can't change the directory of the parent
anyway.

s/CURRENT_DIR/ROOT_DIR/

Authors: @richardtowers