### PR TITLE
TT-1000: Add 'SNAPSHOT' and clean on deploy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ sourceSets {
     }
 }
 
-version = "$version_number-" + System.getenv('BUILD_NUMBER')
+def build_number = System.getenv('BUILD_NUMBER') != null ? System.getenv('BUILD_NUMBER') : 'SNAPSHOT'
+version = "$version_number-" + build_number
 
 distributions {
     main {

--- a/dev-deployment.sh
+++ b/dev-deployment.sh
@@ -32,11 +32,9 @@ cfLogin() {
 
 ./pre-commit.sh
 
-./gradlew distZip
+./gradlew clean distZip
 
 cfLogin
 
-# Finds the most up-to-date zip and deploys that
-zipFile="$(cd build/distributions && echo "$(pwd)/$(ls -t ./*.zip | head -1)")"
-cf push -f dev-manifest.yml -p "$zipFile"
+cf push -f dev-manifest.yml -p build/distributions/verify-service-provider-*.zip
 


### PR DESCRIPTION
Added SNAPSHOT to build artifact if BUILD_NUMBER env variable not set
Add a clean step to the dev-deployment so that only one zip file exists

Authors: @andy-paine