### PR TITLE
TT-1215 Response Translation supports address history

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/UserAccountCreationResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/UserAccountCreationResponseAcceptanceTest.java
@@ -52,6 +52,7 @@ public class UserAccountCreationResponseAcceptanceTest {
             "DATE_OF_BIRTH_VERIFIED",
             "CURRENT_ADDRESS",
             "CURRENT_ADDRESS_VERIFIED",
+            "ADDRESS_HISTORY",
             "CYCLE_3");
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
 
@@ -71,6 +72,7 @@ public class UserAccountCreationResponseAcceptanceTest {
                 "DATE_OF_BIRTH_VERIFIED",
                 "CURRENT_ADDRESS",
                 "CURRENT_ADDRESS_VERIFIED",
+                "ADDRESS_HISTORY",
                 "CYCLE_3");
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/Attributes.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/Attributes.java
@@ -3,8 +3,10 @@ package uk.gov.ida.verifyserviceprovider.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -16,6 +18,7 @@ public class Attributes {
     private final VerifiableAttribute<String>  surname;
     private final VerifiableAttribute<LocalDate> dateOfBirth;
     private final VerifiableAttribute<Address> address;
+    private final List<VerifiableAttribute<Address>> addressHistory;
     private final String cycle3;
 
     @JsonCreator
@@ -25,6 +28,7 @@ public class Attributes {
         @JsonProperty("surname") VerifiableAttribute<String> surname,
         @JsonProperty("dateOfBirth") VerifiableAttribute<LocalDate> dateOfBirth,
         @JsonProperty("address") VerifiableAttribute<Address> address,
+        @JsonProperty("addressHistory") List<VerifiableAttribute<Address>> addressHistory,
         @JsonProperty("cycle3") String cycle3
     ) {
         this.firstName = firstName;
@@ -32,6 +36,7 @@ public class Attributes {
         this.surname = surname;
         this.dateOfBirth = dateOfBirth;
         this.address = address;
+        this.addressHistory = addressHistory;
         this.cycle3 = cycle3;
     }
 
@@ -55,6 +60,10 @@ public class Attributes {
         return address;
     }
 
+    public List<VerifiableAttribute<Address>> getAddressHistory() {
+        return addressHistory;
+    }
+
     public String getCycle3() {
         return cycle3;
     }
@@ -70,6 +79,7 @@ public class Attributes {
         if (surname != null ? !surname.equals(that.surname) : that.surname != null) return false;
         if (dateOfBirth != null ? !dateOfBirth.equals(that.dateOfBirth) : that.dateOfBirth != null) return false;
         if (address != null ? !address.equals(that.address) : that.address != null) return false;
+        if (addressHistory != null ? !(that.addressHistory != null && CollectionUtils.isEqualCollection(addressHistory, that.addressHistory)) : that.addressHistory != null) return false;
         return cycle3 != null ? cycle3.equals(that.cycle3) : that.cycle3 == null;
     }
 
@@ -80,6 +90,7 @@ public class Attributes {
         result = 31 * result + (surname != null ? surname.hashCode() : 0);
         result = 31 * result + (dateOfBirth != null ? dateOfBirth.hashCode() : 0);
         result = 31 * result + (address != null ? address.hashCode() : 0);
+        result = 31 * result + (addressHistory != null ? addressHistory.hashCode() : 0);
         result = 31 * result + (cycle3 != null ? cycle3.hashCode() : 0);
         return result;
     }
@@ -87,8 +98,8 @@ public class Attributes {
     @Override
     public String toString() {
         return String.format(
-            "Attributes{ firstName=%s, middleName=%s, surname=%s, dateOfBirth=%s, address=%s, cycle3=%s}",
-            firstName, middleName, surname, dateOfBirth, address, cycle3);
+            "Attributes{ firstName=%s, middleName=%s, surname=%s, dateOfBirth=%s, address=%s, addressHistory=%s, cycle3=%s}",
+            firstName, middleName, surname, dateOfBirth, address, addressHistory, cycle3);
     }
 
 }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/AttributeTranslationServiceTests.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/AttributeTranslationServiceTests.java
@@ -105,6 +105,36 @@ public class AttributeTranslationServiceTests {
     }
 
     @Test
+    public void shouldReturnAddressHistoryAttribute() {
+        Attribute addressHistoryAttribute = new AddressAttributeBuilder_1_1()
+            .addAddress(new AddressAttributeValueBuilder_1_1()
+                .addLines(Arrays.asList("10 Whitechapel High St", "London"))
+                .withPostcode("E1 8DX")
+                .withFrom(DateTime.parse("2017-07-03"))
+                .withTo(DateTime.parse("2017-07-30"))
+                .withVerified(true)
+                .build())
+            .addAddress(new AddressAttributeValueBuilder_1_1()
+                .addLines(Arrays.asList("42 Old Road", "London"))
+                .withPostcode("W1 0AA")
+                .withFrom(DateTime.parse("2015-01-01"))
+                .withTo(DateTime.parse("2017-07-03"))
+                .withVerified(true)
+                .build())
+            .buildPreviousAddress();
+        addressHistoryAttribute.setName("addresshistory");
+
+        AttributeStatement attributeStatement = anAttributeStatement()
+            .addAttribute(addressHistoryAttribute)
+            .build();
+
+        Attributes result = AttributeTranslationService.translateAttributes(attributeStatement);
+
+        assertThat(result.getAddressHistory()).isNotNull();
+        assertThat(result.getAddressHistory().size()).isEqualTo(2);
+    }
+
+    @Test
     public void shouldIncludeEmptyAttributes() {
         AttributeStatement attributeStatement = anAttributeStatement()
             .addAttribute(new SimpleStringAttributeBuilder()


### PR DESCRIPTION
Address history can now be sent to RPs as part of user account creation.
This updates the VSP to handle translation of address history attribute when it is present in a user account creation response.

Authors: @rachaelbooth