### PR TITLE
TT-1482 - Changing version number not to use jenkins build number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,7 @@ sourceSets {
     }
 }
 
-def build_number = System.getenv('BUILD_NUMBER') != null ? System.getenv('BUILD_NUMBER') : 'SNAPSHOT'
-version = "$version_number-" + build_number
+version = "$version_number"
 
 distributions {
     main {


### PR DESCRIPTION
Making version not to use jenkins build number as it will not be of any significance for RP's who use VSP

Authors: @SKeerthana