### PR TITLE
BAU: Update Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,21 @@ Release notes
 * Improve documentation
 * Improve healthcheck logging
 
+#### Configuration Changes:
+When using environment variables:
+* Replace SERVICE_ENTITY_ID with SERVICE_ENTITY_IDS, which is a JSON string array containing the entity id of the service (or services) using the Verify Service Provider (e.g. '["http://entity-id"]')
+* Remove HUB_METADATA_URL and HUB_SSO_LOCATION
+* Add VERIFY_ENVIRONMENT, specifying the environment of the Verify Hub to run against. Valid values are PRODUCTION, INTEGRATION, or COMPLIANCE_TOOL.
+
+When using a yaml file:
+* Replace serviceEntityId with serviceEntityIds, which is a list containing the entity id (or ids) as above
+* Remove hubSsoLocation and verifyHubMetadata
+* Add verifyHubConfiguration as below. This will contain an environment option specifying which hub environment to use, removing the need to specify the hubSsoLocation or metadata url.
+```
+verifyHubConfiguration:
+  environment: \\ PRODUCTION, INTEGRATION or COMPLIANCE_TOOL
+```
+
 ### 0.3.0
 
 * Fix the expected names of user account creation attributes to match the names the MSA produces

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ Release notes
 
 ### Next
 
+* Add support for the Address History user account creation attribute
+* Add ENVIRONMENT configuration option to replace hubSsoLocation and metadataUrl.
+* Send version number to hub
+* Support multitenancy
+* Improve documentation
+* Improve healthcheck logging
+
 ### 0.3.0
 
 * Fix the expected names of user account creation attributes to match the names the MSA produces


### PR DESCRIPTION
To reduce release pain, we ought to be keeping this vaguely up to date as we add features (although it should always be checked over and maybe reworded when it comes to a release). It seems useful to be in the habit of at least adding a bullet point to remind us what features have been added since the last release.

I was going to add support address history in, then figured I may as well look back at the diff and see what else I can catch - I think this is it, but I'm not completely sure I've caught everything that will be user visible. It's based on the diff since the last tag, which also may well not actually match the last release - I'm not sure. This will all be smoother once we've done the first one using the newly discussed process.