### PR TITLE
Clarified role of Verify Service Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Verify Service Provider
 
-GOV.UK Verify uses SAML (Security Assertion Markup Language) to securely exchange information about identities. A Relying Party can use Verify Service Provider to handle all SAML communication to and from the Verify Hub.
+GOV.UK Verify uses SAML (Security Assertion Markup Language) to securely exchange information about identities. A Relying Party can use Verify Service Provider to generate and translate SAML communication to and from the Verify Hub.
 
 Using Verify Service Provider will make it easier to:
 * connect multiple services with GOV.UK Verify - you only need one instance of Verify Service Provider


### PR DESCRIPTION
Removed reference to Verify Service Provider handling 'all' communication. 

BECAUSE: users will still need to handle sending AuthnRequests. Verify Service Provider cannot do this for them.