### PR TITLE
Library update checker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ project.ext {
 dependencies {
     compile(
         "io.dropwizard:dropwizard-core:$dropwizardVersion",
-        'org.json:json:20170516',
+        'org.json:json:20171018',
         "org.opensaml:opensaml-core:$openSamlVersion",
         "uk.gov.ida:saml-metadata-bindings:$openSamlVersion-$samlMetaDataBindingVersion",
         "org.opensaml:opensaml-saml-impl:$openSamlVersion",
@@ -33,12 +33,12 @@ dependencies {
     testCompile(
         'junit:junit:4.12',
         "io.dropwizard:dropwizard-testing:$dropwizardVersion",
-        'org.mockito:mockito-core:2.7.22',
+        'org.mockito:mockito-core:2.11.0',
         "uk.gov.ida:saml-metadata-bindings-test:$openSamlVersion-$samlMetaDataBindingVersion",
         "uk.gov.ida:common-test-utils:2.0.0-31",
-        "org.jsoup:jsoup:1.10.3",
+        "org.jsoup:jsoup:1.11.1",
     )
-    testCompile('com.github.tomakehurst:wiremock:2.5.1'){ transitive = false }
+    testCompile('com.github.tomakehurst:wiremock:2.10.1'){ transitive = false }
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.ben-manes.versions' version '0.17.0'
+}
+
 apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'idea'

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -3,4 +3,5 @@ set -e
 
 cd "$(dirname "$0")"
 ./gradlew clean test testAcceptance
+./gradlew dependencyUpdates
 


### PR DESCRIPTION
1. Adds gradle plugin to check for available dependency updates.
2. Calls above gradle task in pre-commit to make available dependency updates visible to developers working on the service provider
3. Updates some of the currently out of date dependencies (the easy to do ones...). I've left our saml ones alone since I think Andy said he wants to make some changes during some of those upgrades.