### PR TITLE
BAU: Build on Jenkins2 with OpenJDK

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -1,0 +1,39 @@
+pipeline {
+
+    agent none
+
+    options {
+        disableConcurrentBuilds()
+        timeout(time: 20, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '10',
+                                  artifactNumToKeepStr: '1'))
+    }
+
+    stages {
+        stage('Test') {
+            agent {
+              docker {
+                image 'govukverify/java8:PR-5.6'
+                reuseNode true
+              }
+            }
+            steps {
+                sh './gradlew clean test testAcceptance distZip'
+            }
+        }
+
+        stage('Build') {
+            agent {
+              docker {
+                image 'govukverify/java8:PR-5.6'
+                reuseNode true
+              }
+            }
+            steps {
+                sh './gradlew clean distZip'
+            }
+        }
+
+    }
+}
+

--- a/build.jenkins
+++ b/build.jenkins
@@ -13,7 +13,7 @@ pipeline {
         stage('Test') {
             agent {
               docker {
-                image 'govukverify/java8:PR-5.6'
+                image 'govukverify/java8:latest'
               }
             }
             steps {
@@ -24,7 +24,7 @@ pipeline {
         stage('Build') {
             agent {
               docker {
-                image 'govukverify/java8:PR-5.6'
+                image 'govukverify/java8:latest'
               }
             }
             steps {

--- a/build.jenkins
+++ b/build.jenkins
@@ -14,11 +14,10 @@ pipeline {
             agent {
               docker {
                 image 'govukverify/java8:PR-5.6'
-                reuseNode true
               }
             }
             steps {
-                sh './gradlew clean test testAcceptance distZip'
+                sh './gradlew clean test testAcceptance'
             }
         }
 
@@ -26,7 +25,6 @@ pipeline {
             agent {
               docker {
                 image 'govukverify/java8:PR-5.6'
-                reuseNode true
               }
             }
             steps {


### PR DESCRIPTION
As we'll be using OpenJDK as the basis of our alphagov/java8 build
container on Jenkins2, we need to ensure that VSP will behave as
expected when built in this way.

Note that the build.jenkins in this commit does not contain tag or
publish stages.

Authors: @roryirvine