### PR TITLE
bau: use a random port in tests

### DIFF
--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HubMetadataFeatureTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HubMetadataFeatureTest.java
@@ -60,6 +60,7 @@ public class HubMetadataFeatureTest {
         applicationTestSupport = new DropwizardTestSupport<>(
             VerifyServiceProviderApplication.class,
             "verify-service-provider.yml",
+            config("server.connector.port", "0"),
             config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
             config("verifyHubConfiguration.metadata.uri", () -> String.format("http://localhost:%s/SAML2/metadata", wireMockServer.port())),
             config("msaMetadata.uri", msaServer::getUri),

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
@@ -56,6 +56,7 @@ public class MsaMetadataFeatureTest {
         this.applicationTestSupport = new DropwizardTestSupport<>(
             VerifyServiceProviderApplication.class,
             "verify-service-provider.yml",
+            config("server.connector.port", "0"),
             config("verifyHubConfiguration.metadata.uri", () -> String.format("http://localhost:%s/SAML2/metadata", hubServer.port())),
             config("msaMetadata.uri", () -> String.format("http://localhost:%s/matching-service/metadata", wireMockServer.port())),
             config("verifyHubConfiguration.metadata.expectedEntityId", HUB_ENTITY_ID),


### PR DESCRIPTION
Tests can occasionally fail if something already has the VSP's default
port bound. We can mitigate this failure by overriding this value with 0
 in tests, which will give us a random port.

There are some tests that require a specific port for testing the use of
environment variables, but they require a more complicated fix. Expect
a more complicated PR to follow.