### PR TITLE
BAU: Update default clockSkew to PT30s

### DIFF
--- a/dev-manifest-multi-tenant.yml
+++ b/dev-manifest-multi-tenant.yml
@@ -3,7 +3,7 @@ applications:
   - name: verify-service-provider-dev-multi
     buildpack: java_buildpack
     env:
-      CLOCK_SKEW: PT5s
+      CLOCK_SKEW: PT30s
       SERVICE_ENTITY_IDS: '["http://verify-service-provider-dev-service", "http://passport-verify-stub-relying-party-one", "http://passport-verify-stub-relying-party-two"]'
       VERIFY_ENVIRONMENT: COMPLIANCE_TOOL
       MSA_ENTITY_ID: https://verify-service-provider-stub-msa

--- a/dev-manifest.yml
+++ b/dev-manifest.yml
@@ -3,7 +3,7 @@ applications:
   - name: verify-service-provider-dev
     buildpack: java_buildpack
     env:
-      CLOCK_SKEW: PT5s
+      CLOCK_SKEW: PT30s
       SERVICE_ENTITY_IDS: '["http://verify-service-provider-dev-service"]'
       VERIFY_ENVIRONMENT: COMPLIANCE_TOOL
       MSA_ENTITY_ID: https://verify-service-provider-stub-msa

--- a/local-running/local-config.yml
+++ b/local-running/local-config.yml
@@ -20,7 +20,7 @@ logging:
       currentLogFilename: logs/verify-service-provider.log
       archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
 
-clockSkew: ${CLOCK_SKEW:-PT5s}
+clockSkew: ${CLOCK_SKEW:-PT30s}
 
 serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
 

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -15,7 +15,6 @@ import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfi
 
 import java.util.HashMap;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.apache.xml.security.utils.Base64.decode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,7 +60,7 @@ public class ApplicationConfigurationFeatureTests {
             put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
             put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
-            put("CLOCK_SKEW", "PT5s");
+            put("CLOCK_SKEW", "PT30s");
         }});
 
         application.getTestSupport().before();
@@ -79,7 +78,7 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getSamlSigningKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_SIGNING_KEY));
         assertThat(configuration.getSamlPrimaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
-        assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(5));
+        assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(30));
     }
 
     @Test
@@ -94,7 +93,7 @@ public class ApplicationConfigurationFeatureTests {
             put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
             put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
-            put("CLOCK_SKEW", "PT5s");
+            put("CLOCK_SKEW", "PT30s");
         }});
 
         application.getTestSupport().before();
@@ -112,6 +111,6 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getSamlSigningKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_SIGNING_KEY));
         assertThat(configuration.getSamlPrimaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
-        assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(5));
+        assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(30));
     }
 }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
@@ -52,7 +52,7 @@ public class VerifyServiceProviderConfigurationTest {
             put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
             put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
-            put("CLOCK_SKEW", "PT5s");
+            put("CLOCK_SKEW", "PT30s");
         }});
 
         factory.build(

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -21,7 +21,7 @@ logging:
       currentLogFilename: logs/verify-service-provider.log
       archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
 
-clockSkew: ${CLOCK_SKEW:-PT5s}
+clockSkew: ${CLOCK_SKEW:-PT30s}
 
 # Entity ID (or IDs) that uniquely identifies your service (or services)
 serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}


### PR DESCRIPTION
Verify Service Provider (VSP) and Matching Service Adaptor (MSA) both perform issue instant validation and they both use clock skew for this validation. MSA's default clockSkew is 30 seconds whereas VSP's default clockSkew is 5 seconds. This change ensures that VSP and MSA have same default clockSkew.

Authors: @adityapahuja