### PR TITLE
VCU-87: Java 10 builds mandatory in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ jdk:
 matrix:
   allow_failures:
   - jdk: oraclejdk9
-  - jdk: oraclejdk10
   - jdk: openjdk9
-  - jdk: openjdk10
   - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Build-breaker on JDK:oraclejdk10 and JDK:openjdk10.
Enforce Java 10 compatibility on all VSP changes.