### PR TITLE
49: Upgrade Dropwizard to 1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ PORT                          # (Optional - default 50400) The TCP port where th
 LOG_LEVEL                     # (Optional - default INFO) The threshold level for logs to be written (e.g. DEBUG, INFO, WARN, or ERROR)
 ```
 
-As Verify Service Provider is a Dropwizard application, you can also configure it with all [options provided by Dropwizard](http://www.dropwizard.io/1.1.0/docs/manual/configuration.html).
+As Verify Service Provider is a Dropwizard application, you can also configure it with all [options provided by Dropwizard](http://www.dropwizard.io/1.3.5/docs/manual/configuration.html).
 
 ### Generate keys for testing
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ repositories {
 project.ext {
     version_number = '1.0.0'
     openSamlVersion = '3.3.0'
-    verifyCommonUtils = '2.0.0-336'
-    samlLibVersion = "$openSamlVersion-147"
-    dropwizardVersion = '1.2.0'
+    verifyCommonUtils = '2.0.0-337'
+    samlLibVersion = "$openSamlVersion-152"
+    dropwizardVersion = '1.3.5'
     jaxbapiVersion = '2.2.9'
 }
 
@@ -45,7 +45,7 @@ dependencies {
         'org.mockito:mockito-core:2.12.0',
         "uk.gov.ida:saml-metadata-bindings-test:$samlLibVersion",
         "uk.gov.ida:saml-utils:$samlLibVersion",
-        "uk.gov.ida:common-test-utils:2.0.0-43",
+        "uk.gov.ida:common-test-utils:2.0.0-44",
         "org.jsoup:jsoup:1.11.1",
         "javax.xml.bind:jaxb-api:$jaxbapiVersion",
     )

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnFailedResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnFailedResponseAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -30,9 +31,16 @@ public class AuthnFailedResponseAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ErrorResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ErrorResponseAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -30,9 +31,16 @@ public class ErrorResponseAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/InvalidSamlAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -29,9 +30,16 @@ public class InvalidSamlAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoAuthnContextResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoAuthnContextResponseAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -30,9 +31,16 @@ public class NoAuthnContextResponseAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NoMatchAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -30,9 +31,16 @@ public class NoMatchAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SecondaryEncryptionKeyAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SecondaryEncryptionKeyAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -33,9 +34,16 @@ public class SecondaryEncryptionKeyAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer, TEST_RP_MS_PRIVATE_ENCRYPTION_KEY, "http://verify-service-provider");
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -35,9 +36,16 @@ public class SuccessMatchAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer, configuredEntityId);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Before
     public void setUp() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/TranslateResponseMultiTenantedSetupAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/TranslateResponseMultiTenantedSetupAcceptanceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider;
 import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -33,9 +34,16 @@ public class TranslateResponseMultiTenantedSetupAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer, String.format("%s,%s", configuredEntityIdOne, configuredEntityIdTwo));
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Test
     public void shouldHandleASuccessMatchResponseForCorrectProvidedEntityId() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/UserAccountCreationResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/UserAccountCreationResponseAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
@@ -39,9 +40,16 @@ public class UserAccountCreationResponseAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
-    private static ComplianceToolService complianceTool = new ComplianceToolService(client);
-    private static GenerateRequestService generateRequestService = new GenerateRequestService(client);
+    private static Client client;
+    private static ComplianceToolService complianceTool;
+    private static GenerateRequestService generateRequestService;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+        complianceTool = new ComplianceToolService(client);
+        generateRequestService = new GenerateRequestService(client);
+    }
 
     @Test
     public void shouldHandleAUserAccountCreationResponse() {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/VersionNumberAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/VersionNumberAcceptanceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.ida.verifyserviceprovider;
 
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.ida.verifyserviceprovider.dto.Scenario;
 import uk.gov.ida.verifyserviceprovider.rules.VerifyServiceProviderAppRule;
 
 import javax.ws.rs.client.Client;
@@ -19,7 +19,12 @@ public class VersionNumberAcceptanceTest {
     @ClassRule
     public static VerifyServiceProviderAppRule application = new VerifyServiceProviderAppRule(msaServer);
 
-    private static Client client = application.client();
+    private static Client client;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        client = application.client();
+    }
 
     @Test
     public void shouldRespondWithVersionNumber() {

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -2,7 +2,7 @@
 # the application using a YAML file.
 
 # Dropwizard server connector configuration
-# see: http://www.dropwizard.io/1.1.2/docs/manual/configuration.html#servers
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#servers
 server:
   type: simple
   applicationContextPath: /
@@ -12,7 +12,7 @@ server:
     port: ${PORT:-50400}
 
 # Logging configuration
-# see: http://www.dropwizard.io/1.1.2/docs/manual/configuration.html#logging
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#logging
 logging:
   level: ${LOG_LEVEL:-INFO}
   appenders:


### PR DESCRIPTION
Upgrade Dropwizard to 1.3.5 to fix various security issues.
Update Dropwizard links to use 1.3.5.
Update all test cases to create an instance of client and initialise it before class to avoid getting uninitialised environment.

Authors: @adityapahuja