### PR TITLE
Trello-9IPDOHxR: Update swagger API docs with addressHistory

### DIFF
--- a/docs/api/verify-service-provider-api.swagger.yml
+++ b/docs/api/verify-service-provider-api.swagger.yml
@@ -229,6 +229,15 @@ definitions:
             $ref: '#/definitions/Address'
           verified:
             type: boolean
+      addressHistory:
+        type: array
+        items:
+          type: object
+          properties:
+            value:
+              $ref: '#/definitions/Address'
+            verified:
+              type: boolean
       cycle3:
         type: string
   Address:


### PR DESCRIPTION
- We have since added `addressHistory` translation to the VSP but
we did not update the swagger docs
- This adds a new array of addresses for `addressHistory`