### PR TITLE
BAU: Add more example SAML Assertions

### DIFF
--- a/example-saml/eidas_mds_assertion.xml
+++ b/example-saml/eidas_mds_assertion.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_f4bd7032b194693cfa97796263bfb248" IssueInstant="2018-10-22T16:54:06.581Z" Version="2.0">
+  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://ida-stub-idp-joint.cloudapps.digital/stub-country/ServiceMetadata</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_f4bd7032b194693cfa97796263bfb248">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>WrbUTqq4wB7x/RsllIdn/h6LI6VYTH+Biyfgmkc+nqU=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+MtTYyDjO5OTLFGeCpyQqqUCj6vbhTZjv0bePVm85/QDmG5BDB56RVEd3hjY0pGOfdydfFyQM5iSj
+SgQvS7TSq56UTCmg0GooH9tfGUArjeTbkdRMOeC3pezksDhzYoQOH6r8UM4E7Y8NfCsCrXG8YUkR
+36CJ9LyWWUeDSmubShZ0TLPllab8JSOerRERBlIv168sOnllxf82Ck4L7WZrn6XFpgIhuYeY0Q3d
+KrFdvF1D/itBauTE4NgTeHCkKApVfrCnADRUKP6fK+X5AzS9WNjlDSbkCtVgZUXwdC2XinGv3A4N
+ssoqUll+QEY+kN5VWeisxXmQwzXfFCNSYeFj9R7uM2D5UYH/Bs7fY/PPi45GXl03AnJveqqZTr6N
+EYXLaBxOm+4HceGstXDN+o5refDgrzCXk7Lt+JTn/Zm03S5Rh9h9YJ9EwhKjTWVJ4WaQuEZH28Hf
+yPRtJ2ONNbCgx9ndThMjNmChGBtAu0Gcp1T7qSlQd+pVsrjUteGZsPdYBaAgJF5OwBSxIF87Qls5
+7i772AVGBzkTqbgx9Ygg4+DWLuOEaFsPeP/kLDwhnoP8A89zM5TglZDjyyjYo6dqNhU3oF8GhQkl
+WmzUkYxsllIewY/UuLZ/1UBETIh0hB0hI9ray6LCbAPrKQx7LhQtNz7sFAL2P+C2KbgECrJi5I8=
+</ds:SignatureValue>
+  </ds:Signature>
+  <saml2:Subject>
+    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">UK/EU/9eb0809b-5ed4-44d8-85f2-4a186f444d9e</saml2:NameID>
+    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <saml2:SubjectConfirmationData InResponseTo="_fd22d20f-8972-4f30-a5ab-e7237d91e4fd" NotOnOrAfter="2018-10-22T16:59:06.581Z" Recipient="https://www.joint.signin.service.gov.uk:443/SAML2/SSO/EidasResponse/POST"/>
+    </saml2:SubjectConfirmation>
+  </saml2:Subject>
+  <saml2:Conditions NotBefore="2018-10-22T16:54:06.581Z" NotOnOrAfter="2018-10-22T16:59:06.581Z">
+    <saml2:AudienceRestriction>
+      <saml2:Audience>https://hub-connector-eidas-joint.cloudapps.digital/metadata.xml</saml2:Audience>
+    </saml2:AudienceRestriction>
+  </saml2:Conditions>
+  <saml2:AuthnStatement AuthnInstant="2018-10-22T16:54:06.581Z">
+    <saml2:AuthnContext>
+      <saml2:AuthnContextClassRef>http://eidas.europa.eu/LoA/substantial</saml2:AuthnContextClassRef>
+    </saml2:AuthnContext>
+  </saml2:AuthnStatement>
+  <saml2:AttributeStatement>
+    <saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+      <saml2:AttributeValue xmlns:eidas-natural="http://eidas.europa.eu/attributes/naturalperson" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="eidas-natural:CurrentGivenNameType">Jack</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+      <saml2:AttributeValue xmlns:eidas-natural="http://eidas.europa.eu/attributes/naturalperson" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="eidas-natural:CurrentFamilyNameType">Griffin</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="DateOfBirth" Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+      <saml2:AttributeValue xmlns:eidas-natural="http://eidas.europa.eu/attributes/naturalperson" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="eidas-natural:DateOfBirthType">1983-06-21</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+      <saml2:AttributeValue xmlns:eidas-natural="http://eidas.europa.eu/attributes/naturalperson" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="eidas-natural:PersonIdentifierType">8826379b-744e-4176-aaa2-7dfa480425bb</saml2:AttributeValue>
+    </saml2:Attribute>
+  </saml2:AttributeStatement>
+</saml2:Assertion>

--- a/example-saml/idp_authn_assertion.xml
+++ b/example-saml/idp_authn_assertion.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="_2e666607-0214-49fd-882b-603bcf749676" IssueInstant="2018-10-22T16:41:57.453Z" Version="2.0" xsi:type="saml2:AssertionType">
+  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://stub_idp.acme.org/post-office-test-rp/SSO/POST</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_2e666607-0214-49fd-882b-603bcf749676">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>sNQ0LGXO1YWrk5jLP+VBzlPCJIvpHqTSHnjxXO2povA=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+lCX1RogyFRTeP4QEagQoQk/FnQfkZruB89oqkPK7ffEDP7uvdOkoiz7Bf0k422FygogpTECQ/URB
+HQ+MglnnXtQR7ubCYvY3frN3SjY7qE76Eer6MIJPFwczJqETvdQWATcSXKAMgf0J0hLK7bCaz+/t
+kaGn2bY9JbasTA0Tra6BXsUWMy1yjTQW8L0wLnQmEtj1DPWGP3v5MW4awbwAXBHXYrqx12BYqzsN
+od+yFTh8luxAqHvYbpBF4sEKOK3LGfc6VyVs07JS3MR7sxT19F6QiokXcn0pRlbBHhTebReeFUZh
+klanzqevbPzWCmkPIxtU60ZYAskU8X1ku+V4cA==
+</ds:SignatureValue>
+  </ds:Signature>
+  <saml2:Subject xsi:type="saml2:SubjectType">
+    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">399666cb-215c-471d-8608-16db50db7f8a</saml2:NameID>
+    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer" xsi:type="saml2:SubjectConfirmationType">
+      <saml2:SubjectConfirmationData InResponseTo="_f5390dcc-6866-4f32-8669-c9bffd396b93" NotOnOrAfter="2018-10-22T17:41:57.453Z" Recipient="https://signin.service.gov.uk" xsi:type="saml2:SubjectConfirmationDataType"/>
+    </saml2:SubjectConfirmation>
+  </saml2:Subject>
+  <saml2:AuthnStatement AuthnInstant="2018-10-22T16:41:57.453Z" xsi:type="saml2:AuthnStatementType">
+    <saml2:AuthnContext>
+      <saml2:AuthnContextClassRef>urn:uk:gov:cabinet-office:tc:saml:authn-context:level2</saml2:AuthnContextClassRef>
+    </saml2:AuthnContext>
+  </saml2:AuthnStatement>
+  <saml2:AttributeStatement xsi:type="saml2:AttributeStatementType">
+    <saml2:Attribute FriendlyName="IPAddress" Name="TXN_IPaddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Verified="false" xsi:type="ida:IPAddressType">213.86.153.236</saml2:AttributeValue>
+    </saml2:Attribute>
+  </saml2:AttributeStatement>
+</saml2:Assertion>

--- a/example-saml/idp_mds_assertion.xml
+++ b/example-saml/idp_mds_assertion.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="_8d497d26-7593-4399-a5ac-219c064d5f48" IssueInstant="2018-10-22T16:41:57.453Z" Version="2.0" xsi:type="saml2:AssertionType">
+  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://stub_idp.acme.org/post-office-test-rp/SSO/POST</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_8d497d26-7593-4399-a5ac-219c064d5f48">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>9r13FBWOBwU/auGbco1krXcxUHK6quzlACxnaZBcwJo=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+Q+SOV0pItpI0OVdakOTyJ5jzJi+oLGVPpoVNv9Kf0bO/mh/ZRlOwMnhLqTNNgRjIl6jf1itRgfOg
+6Hr+Y+qiTqIHoicXS5C/a4ts4GrCz1W2b/F4FSc1NtPIxPay4Mof2q3eAn6IXKoUYpO1tuBBS1On
+ru1KU8/gQd2SxepyE63lnr2lGvvxK5YNIFydtP9rmMew1Fwfx5tjxW8p96bRFH0qO+hWMtt3RneP
+z8RGoK3pi4DjW/IqYPLeDQBXieKmxBwJR8FJkre9XtB+UXN6vgErBtSKZHtiGnp9XiSo4lYScDsW
+i4uPnZslrpSS3LcFxHWyr2mwHriK2LlnYjbm+w==
+</ds:SignatureValue>
+  </ds:Signature>
+  <saml2:Subject xsi:type="saml2:SubjectType">
+    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">399666cb-215c-471d-8608-16db50db7f8a</saml2:NameID>
+    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer" xsi:type="saml2:SubjectConfirmationType">
+      <saml2:SubjectConfirmationData InResponseTo="_f5390dcc-6866-4f32-8669-c9bffd396b93" NotOnOrAfter="2018-10-22T17:41:57.453Z" Recipient="https://signin.service.gov.uk" xsi:type="saml2:SubjectConfirmationDataType"/>
+    </saml2:SubjectConfirmation>
+  </saml2:Subject>
+  <saml2:AttributeStatement xsi:type="saml2:AttributeStatementType">
+    <saml2:Attribute FriendlyName="Firstname" Name="MDS_firstname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Language="en-GB" ida:Verified="true" xsi:type="ida:PersonNameType">Jack</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Middlename(s)" Name="MDS_middlename" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Language="en-GB" ida:Verified="true" xsi:type="ida:PersonNameType">Cornelius</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Surname" Name="MDS_surname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Language="en-GB" ida:Verified="true" xsi:type="ida:PersonNameType">Bauer</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Gender" Name="MDS_gender" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Verified="true" xsi:type="ida:GenderType">Male</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Date of Birth" Name="MDS_dateofbirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Verified="true" xsi:type="ida:DateType">1984-02-29</saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Current Address" Name="MDS_currentaddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:Verified="true" xsi:type="ida:AddressType">
+        <ida:Line>1 Two St</ida:Line>
+        <ida:PostCode>1A 2BC</ida:PostCode>
+      </saml2:AttributeValue>
+    </saml2:Attribute>
+    <saml2:Attribute FriendlyName="Previous Address" Name="MDS_previousaddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" xsi:type="saml2:AttributeType">
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:From="2007-09-27" ida:To="2007-09-28" ida:Verified="true" xsi:type="ida:AddressType">
+        <ida:Line>221b Baker St.</ida:Line>
+        <ida:PostCode>W4 1SH</ida:PostCode>
+      </saml2:AttributeValue>
+      <saml2:AttributeValue xmlns:ida="http://www.cabinetoffice.gov.uk/resource-library/ida/attributes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ida:From="2006-09-29" ida:To="2006-09-08" ida:Verified="false" xsi:type="ida:AddressType">
+        <ida:Line>1 Goose Lane</ida:Line>
+        <ida:PostCode>M1 2FG</ida:PostCode>
+      </saml2:AttributeValue>
+    </saml2:Attribute>
+  </saml2:AttributeStatement>
+</saml2:Assertion>

--- a/example-saml/msa_mds_assertion.xml
+++ b/example-saml/msa_mds_assertion.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="_434d7f2e-ca57-4223-90f3-5f40c7bce5e2" IssueInstant="2018-10-22T16:46:25.993Z" Version="2.0" xsi:type="saml2:AssertionType">
+  <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://www.test-rp-ms.gov.uk/SAML2/MD</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_434d7f2e-ca57-4223-90f3-5f40c7bce5e2">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>lN66QQbfoQolW+ozMkzCusdyX2rC9UkWvXZrt9Ll2W8=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+ZDNxrRNO1VvsdsfmbOYeq7cMkWZp7Fg4EeSsDEjk/jDqfbVwewmoTHzKA9zlM0CwZ6MPsu4Arjqh
+uHBBCXl5EeIb2XN/3DGO+GzLmbLblHnxle+5AR5/TdbDlChd9tMRNMYj49IeyGbvm4f+9ANrVEx0
+BMC0qs63R9oJsL8GiVvad5iEFfMTUVA8V7FjK8+c37YsWw17RsIQFUZnpWdumFoN0Eerv0afa46i
+ddUgybKe3ZR/3DmDXhh4iL7a9lG5BgCg5pYjaSZ+mITq4qf7arDsqyFr32RI4oGKxpTaZnkSNDkm
+plsGJGXBB3EZXRrdvCMDApZO3rQFR6gf/g87pg==
+</ds:SignatureValue>
+  </ds:Signature>
+  <saml2:Subject xsi:type="saml2:SubjectType">
+    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">d69876cbe9b1c25db0580a430befca82f42e38570b08c6ff493d4694cb027ba0</saml2:NameID>
+    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer" xsi:type="saml2:SubjectConfirmationType">
+      <saml2:SubjectConfirmationData InResponseTo="_f5390dcc-6866-4f32-8669-c9bffd396b93" NotOnOrAfter="2018-10-22T17:46:25.993Z" Recipient="https://test-rp-stub-integration.ida.digital.cabinet-office.gov.uk:443/test-rp/login" xsi:type="saml2:SubjectConfirmationDataType"/>
+    </saml2:SubjectConfirmation>
+  </saml2:Subject>
+  <saml2:Conditions xsi:type="saml2:ConditionsType">
+    <saml2:AudienceRestriction xsi:type="saml2:AudienceRestrictionType">
+      <saml2:Audience>http://www.test-rp.gov.uk/SAML2/MD</saml2:Audience>
+    </saml2:AudienceRestriction>
+  </saml2:Conditions>
+  <saml2:AuthnStatement AuthnInstant="2018-10-22T16:46:25.993Z" xsi:type="saml2:AuthnStatementType">
+    <saml2:AuthnContext>
+      <saml2:AuthnContextClassRef>urn:uk:gov:cabinet-office:tc:saml:authn-context:level2</saml2:AuthnContextClassRef>
+    </saml2:AuthnContext>
+  </saml2:AuthnStatement>
+</saml2:Assertion>


### PR DESCRIPTION
- We will need to support 4 different kinds of assertion eventually so
  add some examples to reference off when trying to process them
- Adds both types of IDP assertion, a country assertion and an MSA
  assertion (there is already one of these but nice to regenerate in
case it has changed)

Co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>