### PR TITLE
B0ez3pkf validate assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ project.ext {
     samlLibVersion = "$openSamlVersion-152"
     dropwizardVersion = '1.3.5'
     jaxbapiVersion = '2.2.9'
+    hub_saml="$openSamlVersion-15606"
+
 }
 
 dependencies {
@@ -36,7 +38,8 @@ dependencies {
         "uk.gov.ida:common-utils:$verifyCommonUtils",
         "uk.gov.ida:saml-serializers:$samlLibVersion",
         "uk.gov.ida:saml-security:$samlLibVersion",
-        "uk.gov.ida:saml-extensions:$samlLibVersion"
+        "uk.gov.ida:saml-extensions:$samlLibVersion",
+        "uk.gov.ida:hub-saml:$hub_saml"
     )
     compile("commons-collections:commons-collections:3.2.2") { force = true }
     testCompile(
@@ -48,6 +51,7 @@ dependencies {
         "uk.gov.ida:common-test-utils:2.0.0-44",
         "org.jsoup:jsoup:1.11.1",
         "javax.xml.bind:jaxb-api:$jaxbapiVersion",
+        "uk.gov.ida:hub-saml-test-utils:$hub_saml",
     )
     testCompile('com.github.tomakehurst:wiremock:2.11.0'){ transitive = false }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -112,7 +112,7 @@ public class VerifyServiceProviderFactory {
         return new TranslateNonMatchingSamlResponseResource(
                 responseFactory.createResponseService(
                         getHubSignatureTrustEngine(),
-                        responseFactory.createNonMatchingAssertionService(),
+                        responseFactory.createNonMatchingAssertionService(getMsaSignatureTrustEngine(), dateTimeComparator),
                         dateTimeComparator
                 ),
                 entityIdService

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -112,7 +112,7 @@ public class VerifyServiceProviderFactory {
         return new TranslateNonMatchingSamlResponseResource(
                 responseFactory.createResponseService(
                         getHubSignatureTrustEngine(),
-                        responseFactory.createNonMatchingAssertionService(getMsaSignatureTrustEngine(), dateTimeComparator),
+                        responseFactory.createNonMatchingAssertionService(getHubSignatureTrustEngine(), dateTimeComparator),
                         dateTimeComparator
                 ),
                 entityIdService

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -104,8 +104,20 @@ public class ResponseFactory {
         );
     }
 
-    public NonMatchingAssertionService createNonMatchingAssertionService() {
-        return new NonMatchingAssertionService();
+    public NonMatchingAssertionService createNonMatchingAssertionService(ExplicitKeySignatureTrustEngine signatureTrustEngine,
+                                                                         DateTimeComparator dateTimeComparator) {
+
+        MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(signatureTrustEngine);
+        SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
+        TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
+
+        SamlAssertionsSignatureValidator assertionsSignatureValidator = new SamlAssertionsSignatureValidator(samlMessageSignatureValidator);
+        AssertionValidator assertionValidator = new AssertionValidator(
+                new InstantValidator(dateTimeComparator),
+                new SubjectValidator(timeRestrictionValidator),
+                new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator())
+        );
+        return new NonMatchingAssertionService(assertionsSignatureValidator, assertionValidator);
     }
 
     private MetadataBackedSignatureValidator createMetadataBackedSignatureValidator(ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider.factories.saml;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.deserializers.OpenSamlXMLObjectUnmarshaller;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
@@ -99,8 +100,8 @@ public class ResponseFactory {
         );
 
         return new MatchingAssertionService(
-            assertionsSignatureValidator,
-            assertionValidator
+            assertionValidator,
+            assertionsSignatureValidator
         );
     }
 
@@ -117,7 +118,14 @@ public class ResponseFactory {
                 new SubjectValidator(timeRestrictionValidator),
                 new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator())
         );
-        return new NonMatchingAssertionService(assertionsSignatureValidator, assertionValidator);
+        AssertionAttributeStatementValidator attributeStatementValidator = new AssertionAttributeStatementValidator();
+
+        return new NonMatchingAssertionService(
+                assertionsSignatureValidator,
+                new SubjectValidator(timeRestrictionValidator),
+                new AssertionAttributeStatementValidator()
+        );
+
     }
 
     private MetadataBackedSignatureValidator createMetadataBackedSignatureValidator(ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
@@ -6,7 +6,6 @@ import org.opensaml.saml.saml2.core.StatusCode;
 import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
-//import uk.gov.ida.saml.core.
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
@@ -20,22 +19,13 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 
 public abstract class AssertionService {
-    protected final AssertionValidator assertionValidator;
 
-    protected SamlAssertionsSignatureValidator assertionsSignatureValidator;
+    final AssertionValidator assertionValidator;
 
-    protected  AssertionAttributeStatementValidator attributeStatementValidator;
+    final SamlAssertionsSignatureValidator assertionsSignatureValidator;
 
+    private final AssertionAttributeStatementValidator attributeStatementValidator;
 
-    public AssertionService(AssertionValidator assertionValidator,
-                            SamlAssertionsSignatureValidator hubSignatureValidator
-                            ) {
-
-        this(hubSignatureValidator,assertionValidator);
-
-
-        this.attributeStatementValidator = new AssertionAttributeStatementValidator();
-    }
 
     public AssertionService(SamlAssertionsSignatureValidator assertionsSignatureValidator,
                             AssertionValidator assertionValidator)

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
@@ -1,20 +1,66 @@
 package uk.gov.ida.verifyserviceprovider.services;
 
+import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+//import uk.gov.ida.saml.core.
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
-
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.*;
+import javax.xml.namespace.QName;
 import java.util.List;
 
-public interface AssertionService {
+import static java.util.Collections.singletonList;
 
-    TranslatedResponseBody translateSuccessResponse(
-        List<Assertion> assertions,
-        String expectedInResponseTo,
-        LevelOfAssurance expectedLevelOfAssurance,
-        String entityId
+public abstract class AssertionService {
+
+   /* protected final InstantValidator instantValidator;
+    protected final SubjectValidator subjectValidator;
+    protected final ConditionsValidator conditionsValidator;
+    //private final SamlAssertionsSignatureValidator hubSignatureValidator;
+   //private final AssertionAttributeStatementValidator attributeStatementValidator; */
+
+    protected abstract TranslatedResponseBody translateSuccessResponse(
+            List<Assertion> assertions,
+            String expectedInResponseTo,
+            LevelOfAssurance expectedLevelOfAssurance,
+            String entityId
     );
 
-    TranslatedResponseBody translateNonSuccessResponse(StatusCode statusCode);
+    protected abstract TranslatedResponseBody translateNonSuccessResponse(StatusCode statusCode);
+
+    protected void validateHubAssertion(Assertion assertion,
+                                        //String expectedInResponseTo,
+                                        String hubEntityId,
+                                        QName role) {
+
+        if (assertion.getIssueInstant() == null) {
+            throw new SamlResponseValidationException("Assertion IssueInstant is missing.");
+        }
+
+        if (assertion.getID() == null || assertion.getID().length() == 0) {
+            throw new SamlResponseValidationException("Assertion Id is missing or blank.");
+        }
+
+        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing or blank Issuer.");
+        }
+
+        if (assertion.getVersion() == null) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing Version.");
+        }
+
+        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " declared an illegal Version attribute value.");
+        }
+
+        /**hubSignatureValidator.validate(singletonList(assertion), role);
+        subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
+        attributeStatementValidator.validate(assertion);*/
+    }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionService.java
@@ -1,78 +1,21 @@
 package uk.gov.ida.verifyserviceprovider.services;
 
-import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.StatusCode;
-import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
-import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
-import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
-import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
-import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
-import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
-import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
-import uk.gov.ida.verifyserviceprovider.validators.*;
-import javax.xml.namespace.QName;
+
 import java.util.List;
 
-import static java.util.Collections.singletonList;
+public interface AssertionService {
 
-public abstract class AssertionService {
-
-    final AssertionValidator assertionValidator;
-
-    final SamlAssertionsSignatureValidator assertionsSignatureValidator;
-
-    private final AssertionAttributeStatementValidator attributeStatementValidator;
-
-
-    public AssertionService(SamlAssertionsSignatureValidator assertionsSignatureValidator,
-                            AssertionValidator assertionValidator)
-    {
-        this.assertionsSignatureValidator = assertionsSignatureValidator;
-
-        this.assertionValidator = assertionValidator;
-
-        this.attributeStatementValidator = new AssertionAttributeStatementValidator();
-    }
-
-    protected abstract TranslatedResponseBody translateSuccessResponse(
+    TranslatedResponseBody translateSuccessResponse(
             List<Assertion> assertions,
             String expectedInResponseTo,
             LevelOfAssurance expectedLevelOfAssurance,
             String entityId
     );
 
-    protected abstract TranslatedResponseBody translateNonSuccessResponse(StatusCode statusCode);
-
-    public void validateIdPAssertion(Assertion assertion,
-                                     String expectedInResponseTo,
-                                     QName role) {
-
-        if (assertion.getIssueInstant() == null) {
-            throw new SamlResponseValidationException("Assertion IssueInstant is missing.");
-        }
-
-        if (assertion.getID() == null || assertion.getID().length() == 0) {
-            throw new SamlResponseValidationException("Assertion Id is missing or blank.");
-        }
-
-        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0) {
-            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing or blank Issuer.");
-        }
-
-        if (assertion.getVersion() == null) {
-            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing Version.");
-        }
-
-        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
-            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " declared an illegal Version attribute value.");
-        }
-
-        assertionsSignatureValidator.validate(singletonList(assertion), role);
-        assertionValidator.getSubjectValidator().validate(assertion.getSubject(), expectedInResponseTo);
-        attributeStatementValidator.validate(assertion);
-    }
+    TranslatedResponseBody translateNonSuccessResponse( StatusCode statusCode);
 
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionService.java
@@ -23,7 +23,7 @@ import static java.util.Optional.ofNullable;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.ACCOUNT_CREATION;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
 
-public class MatchingAssertionService implements AssertionService {
+public class MatchingAssertionService extends AssertionService                                                                                                                                                                                                  {
 
     private final SamlAssertionsSignatureValidator assertionsSignatureValidator;
     private final AssertionValidator assertionValidator;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionService.java
@@ -23,16 +23,17 @@ import static java.util.Optional.ofNullable;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.ACCOUNT_CREATION;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
 
-public class MatchingAssertionService extends AssertionService                                                                                                                                                                                                  {
+public class MatchingAssertionService implements AssertionService {
 
 
-    public MatchingAssertionService(
-        SamlAssertionsSignatureValidator assertionsSignatureValidator,
-        AssertionValidator assertionValidator
-    ) {
-        super(assertionsSignatureValidator,assertionValidator);
+    private AssertionValidator assertionValidator;
+    private SamlAssertionsSignatureValidator assertionsSignatureValidator;
 
+    public MatchingAssertionService( AssertionValidator assertionValidator, SamlAssertionsSignatureValidator assertionsSignatureValidator ) {
+        this.assertionValidator = assertionValidator;
+        this.assertionsSignatureValidator = assertionsSignatureValidator;
     }
+
 
     public TranslatedResponseBody translateSuccessResponse(
             List<Assertion> assertions,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
@@ -2,15 +2,23 @@ package uk.gov.ida.verifyserviceprovider.services;
 
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-public class NonMatchingAssertionService implements AssertionService {
+import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS;
+import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_PIDS;
+
+public class NonMatchingAssertionService extends AssertionService {
+    private enum AssertionType {AUTHN_ASSERTION, MDS_ASSERTION}
 
     public NonMatchingAssertionService() {
+
     }
 
     @Override
@@ -19,10 +27,45 @@ public class NonMatchingAssertionService implements AssertionService {
         return translateAssertions(assertions);
     }
 
-    private void validateAssertions(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
-        throw new SamlResponseValidationException("Oops");
-    }
+    private void validateAssertions(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String hubEntityId) {
 
+        Map<AssertionType, List<Assertion>> assertionMap = assertions.stream()
+                .collect(Collectors.groupingBy(this::classifyAssertion));
+
+        List<Assertion> authnAssertions = assertionMap.get(AssertionType.AUTHN_ASSERTION);
+        if (authnAssertions == null || authnAssertions.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one authn statement is expected.");
+        }
+
+        List<Assertion> mdsAssertions = assertionMap.get(AssertionType.MDS_ASSERTION);
+        if (mdsAssertions == null || mdsAssertions.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one matching dataset assertion is expected.");
+        }
+
+        Assertion authnAssertion = authnAssertions.get(0);
+        Assertion mdsAssertion = mdsAssertions.get(0);
+
+        validateHubAssertion(authnAssertion, hubEntityId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        //validateHubAssertion(mdsAssertion, requestId, hubEntityId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        //assertionMap.getOrDefault(AssertionType.CYCLE_3_ASSERTION, emptyList()).forEach(a -> validateCycle3Assertion(a, requestId, hubEntityId));
+
+        if (!mdsAssertion.getIssuer().getValue().equals(authnAssertion.getIssuer().getValue())) {
+            throw new SamlResponseValidationException(MISMATCHED_ISSUERS);
+        }
+
+        if (!mdsAssertion.getSubject().getNameID().getValue().equals(authnAssertion.getSubject().getNameID().getValue())) {
+            throw new SamlResponseValidationException(MISMATCHED_PIDS);
+        }
+    }
+    private AssertionType classifyAssertion(Assertion assertion) {
+        if (!assertion.getAuthnStatements().isEmpty()) {
+            return AssertionType.AUTHN_ASSERTION;
+        }
+        else {
+                return AssertionType.MDS_ASSERTION;
+        }
+    }
     private TranslatedResponseBody translateAssertions(List<Assertion> assertions) {
         return null;
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
@@ -1,39 +1,53 @@
 package uk.gov.ida.verifyserviceprovider.services;
 
+import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
-import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 
+import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_PIDS;
 
-public class NonMatchingAssertionService extends AssertionService {
+public class NonMatchingAssertionService implements AssertionService {
 
     private enum AssertionType {AUTHN_ASSERTION, MDS_ASSERTION}
 
-    public NonMatchingAssertionService(SamlAssertionsSignatureValidator assertionsSignatureValidator,
-                                       AssertionValidator assertionValidator){
+    private final SamlAssertionsSignatureValidator assertionsSignatureValidator;
+    private final SubjectValidator subjectValidator;
+    private final AssertionAttributeStatementValidator attributeStatementValidator;
 
-        super(assertionsSignatureValidator,assertionValidator);
+    public NonMatchingAssertionService(
+            SamlAssertionsSignatureValidator assertionsSignatureValidator,
+            SubjectValidator subjectValidator,
+            AssertionAttributeStatementValidator attributeStatementValidator ) {
+
+
+        this.assertionsSignatureValidator = assertionsSignatureValidator;
+        this.subjectValidator = subjectValidator;
+
+        this.attributeStatementValidator = attributeStatementValidator;
     }
 
     @Override
-    public TranslatedResponseBody translateSuccessResponse(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
+    public TranslatedResponseBody translateSuccessResponse( List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId ) {
         validate(assertions, expectedInResponseTo, expectedLevelOfAssurance);
         return translateAssertions(assertions);
     }
 
 
-    public void validate(List<Assertion> assertions, String requestId, LevelOfAssurance expectedLevelOfAssurance) {
+    public void validate( List<Assertion> assertions, String requestId, LevelOfAssurance expectedLevelOfAssurance ) {
 
         Map<AssertionType, List<Assertion>> assertionMap = assertions.stream()
                 .collect(Collectors.groupingBy(this::classifyAssertion));
@@ -63,20 +77,50 @@ public class NonMatchingAssertionService extends AssertionService {
             throw new SamlResponseValidationException(MISMATCHED_PIDS);
         }
     }
-    private AssertionType classifyAssertion (Assertion assertion) {
+
+    public void validateIdPAssertion( Assertion assertion,
+                                      String expectedInResponseTo,
+                                      QName role ) {
+
+        if (assertion.getIssueInstant() == null) {
+            throw new SamlResponseValidationException("Assertion IssueInstant is missing.");
+        }
+
+        if (assertion.getID() == null || assertion.getID().length() == 0) {
+            throw new SamlResponseValidationException("Assertion Id is missing or blank.");
+        }
+
+        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing or blank Issuer.");
+        }
+
+        if (assertion.getVersion() == null) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing Version.");
+        }
+
+        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " declared an illegal Version attribute value.");
+        }
+
+        assertionsSignatureValidator.validate(singletonList(assertion), role);
+        subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
+        attributeStatementValidator.validate(assertion);
+    }
+
+    private AssertionType classifyAssertion( Assertion assertion ) {
         if (!assertion.getAuthnStatements().isEmpty()) {
             return AssertionType.AUTHN_ASSERTION;
-        }
-        else {
-                return AssertionType.MDS_ASSERTION;
+        } else {
+            return AssertionType.MDS_ASSERTION;
         }
     }
-    private TranslatedResponseBody translateAssertions(List<Assertion> assertions) {
+
+    private TranslatedResponseBody translateAssertions( List<Assertion> assertions ) {
         return null;
     }
 
     @Override
-    public TranslatedResponseBody translateNonSuccessResponse(StatusCode statusCode) {
+    public TranslatedResponseBody translateNonSuccessResponse( StatusCode statusCode ) {
         return null;
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
@@ -65,8 +65,8 @@ public class NonMatchingAssertionService implements AssertionService {
         Assertion authnAssertion = authnAssertions.get(0);
         Assertion mdsAssertion = mdsAssertions.get(0);
 
-        validateIdPAssertion(authnAssertion, requestId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-        validateIdPAssertion(mdsAssertion, requestId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        validateIdpAssertion(authnAssertion, requestId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        validateIdpAssertion(mdsAssertion, requestId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
 
         if (!mdsAssertion.getIssuer().getValue().equals(authnAssertion.getIssuer().getValue())) {
@@ -78,7 +78,7 @@ public class NonMatchingAssertionService implements AssertionService {
         }
     }
 
-    public void validateIdPAssertion( Assertion assertion,
+    public void validateIdpAssertion( Assertion assertion,
                                       String expectedInResponseTo,
                                       QName role ) {
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/validators/AssertionValidator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/validators/AssertionValidator.java
@@ -23,6 +23,18 @@ public class AssertionValidator {
         this.conditionsValidator = conditionsValidator;
     }
 
+    public InstantValidator getInstantValidator() {
+        return instantValidator;
+    }
+
+    public SubjectValidator getSubjectValidator() {
+        return subjectValidator;
+    }
+
+    public ConditionsValidator getConditionsValidator() {
+        return conditionsValidator;
+    }
+
     public void validate(Assertion assertion, String expectedInResponseTo, String entityId) {
         instantValidator.validate(assertion.getIssueInstant(), "Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/validators/AssertionValidator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/validators/AssertionValidator.java
@@ -23,18 +23,6 @@ public class AssertionValidator {
         this.conditionsValidator = conditionsValidator;
     }
 
-    public InstantValidator getInstantValidator() {
-        return instantValidator;
-    }
-
-    public SubjectValidator getSubjectValidator() {
-        return subjectValidator;
-    }
-
-    public ConditionsValidator getConditionsValidator() {
-        return conditionsValidator;
-    }
-
     public void validate(Assertion assertion, String expectedInResponseTo, String entityId) {
         instantValidator.validate(assertion.getIssueInstant(), "Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
@@ -1,0 +1,263 @@
+package unit.uk.gov.ida.verifyserviceprovider.services;
+
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
+
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+import uk.gov.ida.verifyserviceprovider.services.NonMatchingAssertionService;
+import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.aCycle3DatasetAssertion;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.ConditionsBuilder.aConditions;
+import static uk.gov.ida.saml.core.test.builders.IPAddressAttributeBuilder.anIPAddress;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SignatureBuilder.aSignature;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+public class NonMatchingAssertionServiceTest {
+
+    private NonMatchingAssertionService nonMatchingAssertionService;
+    @Mock
+     private AssertionValidator assertionValidator;
+
+    @Mock
+    private InstantValidator instantValidator;
+
+    @Mock
+    private SubjectValidator subjectValidator;
+
+    @Mock
+    private ConditionsValidator conditionsValidator;
+
+    @Mock
+    private SamlAssertionsSignatureValidator hubSignatureValidator;
+
+
+    @Mock
+    private VerifyMatchingDatasetUnmarshaller verifyMatchingDatasetUnmarshaller;
+
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        IdaSamlBootstrap.bootstrap();
+        initMocks(this);
+
+        assertionValidator = new AssertionValidator(instantValidator,subjectValidator,conditionsValidator);
+
+        nonMatchingAssertionService = new NonMatchingAssertionService(hubSignatureValidator,
+                assertionValidator
+        );
+        doNothing().when(assertionValidator.getInstantValidator()).validate(any(), any());
+        doNothing().when(assertionValidator.getSubjectValidator()).validate(any(), any());
+        doNothing().when(assertionValidator.getConditionsValidator()).validate(any(), any());
+        when(hubSignatureValidator.validate(any(), any())).thenReturn(mock(ValidatedAssertions.class));
+
+        DateTimeFreezer.freezeTime();
+    }
+
+    @After
+    public void tearDown() {
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssueInstantMissingWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssueInstant(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion IssueInstant is missing.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAssertionIdIsMissingWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setID(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Id is missing or blank.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAssertionIdIsBlankWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setID("");
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Id is missing or blank.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerMissingWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerValueMissingWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(anIssuer().withIssuerId(null).build());
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerValueIsBlankWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(anIssuer().withIssuerId("").build());
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfMissingAssertionVersionWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setVersion(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion has missing Version.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+
+    @Test
+    public void shouldThrowExceptionIfAssertionVersionInvalidWhenValidatingIdPAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setVersion(SAMLVersion.VERSION_10);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion declared an illegal Version attribute value.");
+        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionsWhenAssertionsAreValid() {
+        List<Assertion> assertions = asList(
+                aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted(),
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, "requestId").buildUnencrypted());
+
+        nonMatchingAssertionService.validate(assertions,"requestId", LevelOfAssurance.LEVEL_1);
+
+        verify(assertionValidator.getSubjectValidator(), times(2)).validate(any(), any());
+        verify(hubSignatureValidator, times(2)).validate(any(), any());
+    }
+
+
+
+    public static AssertionBuilder aMatchingDatasetAssertionWithSignature(List<Attribute> attributes, Signature signature, String requestId) {
+        return anAssertion()
+                .withId("mds-assertion")
+                .withIssuer(anIssuer().withIssuerId(STUB_IDP_ONE).build())
+                .withSubject(anAssertionSubject(requestId))
+                .withSignature(signature)
+                .addAttributeStatement(anAttributeStatement().addAllAttributes(attributes).build())
+                .withConditions(aConditions().build());
+    }
+
+    public static AssertionBuilder anAuthnStatementAssertion(String authnContext, String inResponseTo) {
+        return anAssertion()
+                .addAuthnStatement(
+                        anAuthnStatement()
+                                .withAuthnContext(
+                                        anAuthnContext()
+                                                .withAuthnContextClassRef(
+                                                        anAuthnContextClassRef()
+                                                                .withAuthnContextClasRefValue(authnContext)
+                                                                .build())
+                                                .build())
+                                .build())
+                .withSubject(
+                        aSubject()
+                                .withSubjectConfirmation(
+                                        aSubjectConfirmation()
+                                                .withSubjectConfirmationData(
+                                                        aSubjectConfirmationData()
+                                                                .withInResponseTo(inResponseTo)
+                                                                .build()
+                                                ).build()
+                                ).build())
+                .withIssuer(anIssuer().withIssuerId(STUB_IDP_ONE).build())
+                .addAttributeStatement(anAttributeStatement().addAttribute(anIPAddress().build()).build());
+    }
+
+    public static Subject anAssertionSubject(final String inResponseTo) {
+        return aSubject()
+                .withSubjectConfirmation(
+                        aSubjectConfirmation()
+                                .withSubjectConfirmationData(
+                                        aSubjectConfirmationData()
+                                                .withNotOnOrAfter(DateTime.now())
+                                                .withInResponseTo(inResponseTo)
+                                                .build()
+                                ).build()
+                ).build();
+    }
+
+    public static Signature anIdpSignature() {
+        return aSignature().withSigningCredential(
+                new TestCredentialFactory(STUB_IDP_PUBLIC_PRIMARY_CERT, STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY)
+                        .getSigningCredential()).build();
+
+    }
+
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
@@ -82,9 +82,6 @@ public class NonMatchingAssertionServiceTest {
     @Mock
     private AssertionAttributeStatementValidator attributeStatementValidator;
 
-    @Mock
-    private VerifyMatchingDatasetUnmarshaller verifyMatchingDatasetUnmarshaller;
-
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -113,84 +110,84 @@ public class NonMatchingAssertionServiceTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfIssueInstantMissingWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfIssueInstantMissingWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setIssueInstant(null);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion IssueInstant is missing.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfAssertionIdIsMissingWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfAssertionIdIsMissingWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setID(null);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion Id is missing or blank.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfAssertionIdIsBlankWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfAssertionIdIsBlankWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setID("");
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion Id is missing or blank.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfIssuerMissingWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfIssuerMissingWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setIssuer(null);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfIssuerValueMissingWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfIssuerValueMissingWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setIssuer(anIssuer().withIssuerId(null).build());
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfIssuerValueIsBlankWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfIssuerValueIsBlankWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setIssuer(anIssuer().withIssuerId("").build());
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
-    public void shouldThrowExceptionIfMissingAssertionVersionWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfMissingAssertionVersionWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setVersion(null);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing Version.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
 
     @Test
-    public void shouldThrowExceptionIfAssertionVersionInvalidWhenValidatingIdPAssertion() {
+    public void shouldThrowExceptionIfAssertionVersionInvalidWhenValidatingIdpAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setVersion(SAMLVersion.VERSION_10);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion declared an illegal Version attribute value.");
-        nonMatchingAssertionService.validateIdPAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.ida.saml.core.test.TestCredentialFactory;
 import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
 import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
 
+import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
@@ -78,6 +79,8 @@ public class NonMatchingAssertionServiceTest {
     @Mock
     private SamlAssertionsSignatureValidator hubSignatureValidator;
 
+    @Mock
+    private AssertionAttributeStatementValidator attributeStatementValidator;
 
     @Mock
     private VerifyMatchingDatasetUnmarshaller verifyMatchingDatasetUnmarshaller;
@@ -93,12 +96,12 @@ public class NonMatchingAssertionServiceTest {
 
         assertionValidator = new AssertionValidator(instantValidator,subjectValidator,conditionsValidator);
 
-        nonMatchingAssertionService = new NonMatchingAssertionService(hubSignatureValidator,
-                assertionValidator
+        nonMatchingAssertionService = new NonMatchingAssertionService(
+                hubSignatureValidator,
+                subjectValidator,
+                attributeStatementValidator
         );
-        doNothing().when(assertionValidator.getInstantValidator()).validate(any(), any());
-        doNothing().when(assertionValidator.getSubjectValidator()).validate(any(), any());
-        doNothing().when(assertionValidator.getConditionsValidator()).validate(any(), any());
+        doNothing().when(subjectValidator).validate(any(), any());
         when(hubSignatureValidator.validate(any(), any())).thenReturn(mock(ValidatedAssertions.class));
 
         DateTimeFreezer.freezeTime();
@@ -198,7 +201,7 @@ public class NonMatchingAssertionServiceTest {
 
         nonMatchingAssertionService.validate(assertions,"requestId", LevelOfAssurance.LEVEL_1);
 
-        verify(assertionValidator.getSubjectValidator(), times(2)).validate(any(), any());
+        verify(subjectValidator, times(2)).validate(any(), any());
         verify(hubSignatureValidator, times(2)).validate(any(), any());
     }
 

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
@@ -119,7 +119,7 @@ public class ResponseServiceTest {
         SubjectValidator subjectValidator = new SubjectValidator(timeRestrictionValidator);
         ConditionsValidator conditionsValidator = new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator());
         AssertionValidator assertionValidator = new AssertionValidator(instantValidator, subjectValidator, conditionsValidator);
-        MatchingAssertionService matchingAssertionService = new MatchingAssertionService(samlAssertionsSignatureValidator, assertionValidator);
+        MatchingAssertionService matchingAssertionService = new MatchingAssertionService(assertionValidator, samlAssertionsSignatureValidator);
 
         ExplicitKeySignatureTrustEngine signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(hubMetadataResolver);
 


### PR DESCRIPTION
- Changed Assertion Service interface into Abstract class. So as to be able to reuse common
   functionality.
- Modified Matching Assertion Service class to use AssertionValidator
- Enhanced Non-matching Assertion Service class
- Right now there are 2 constructors in the base really there should be one
