### PR TITLE
BAU: Remove Oracle JDK10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,12 @@ env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
   - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11
 matrix:
   allow_failures:
-  - jdk: oraclejdk9
-  - jdk: openjdk9
   - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
- This is deprecated according to Travis & Oracle
- See https://www.oracle.com/technetwork/java/javase/eol-135779.html for
  more detail