### PR TITLE
ss7ycIZj: Hash PIDs in the VSP

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
@@ -28,6 +28,7 @@ public class AuthnRequestAcceptanceTest {
 
     private static String COMPLIANCE_TOOL_HOST = "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk";
     private static String SINGLE_ENTITY_ID = "http://default-entity-id";
+    private static String HASHING_ENTITY_ID = "http://default-entity-id";
     private static String MULTI_ENTITY_ID_1 = "http://service-entity-id-one";
     private static String MULTI_ENTITY_ID_2 = "http://service-entity-id-two";
 
@@ -39,6 +40,7 @@ public class AuthnRequestAcceptanceTest {
         ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
         ConfigOverride.config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
         ConfigOverride.config("serviceEntityIds", SINGLE_ENTITY_ID),
+        ConfigOverride.config("hashingEntityId", HASHING_ENTITY_ID),
         ConfigOverride.config("msaMetadata.expectedEntityId", "some-msa-expected-entity-id"),
         ConfigOverride.config("msaMetadata.uri", "http://some-msa-uri"),
         ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)
@@ -52,6 +54,7 @@ public class AuthnRequestAcceptanceTest {
         ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
         ConfigOverride.config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
         ConfigOverride.config("serviceEntityIds", String.format("%s,%s", MULTI_ENTITY_ID_1, MULTI_ENTITY_ID_2)),
+        ConfigOverride.config("hashingEntityId", HASHING_ENTITY_ID),
         ConfigOverride.config("msaMetadata.expectedEntityId", "some-msa-expected-entity-id"),
         ConfigOverride.config("msaMetadata.uri", "http://some-msa-uri"),
         ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
@@ -17,6 +17,7 @@ public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServic
             VerifyServiceProviderApplication.class,
             "verify-service-provider.yml",
             ConfigOverride.config("serviceEntityIds", serviceEntityIdOverride),
+            ConfigOverride.config("hashingEntityId", "some-hashing-entity-id"),
             ConfigOverride.config("server.connector.port", String.valueOf(0)),
             ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
             ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/AuthnContextMissingException.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/AuthnContextMissingException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.verifyserviceprovider.exceptions;
+
+public class AuthnContextMissingException extends RuntimeException {
+    public AuthnContextMissingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/NoHashingEntityIdIsProvidedError.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/NoHashingEntityIdIsProvidedError.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.verifyserviceprovider.exceptions;
+
+public class NoHashingEntityIdIsProvidedError extends RuntimeException {
+    public NoHashingEntityIdIsProvidedError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -112,7 +112,10 @@ public class VerifyServiceProviderFactory {
         return new TranslateNonMatchingSamlResponseResource(
                 responseFactory.createResponseService(
                         getHubSignatureTrustEngine(),
-                        responseFactory.createNonMatchingAssertionService(getHubSignatureTrustEngine(), dateTimeComparator),
+                        responseFactory.createNonMatchingAssertionService(
+                                getHubSignatureTrustEngine(),
+                                dateTimeComparator,
+                                configuration.getHashingEntityId()),
                         dateTimeComparator
                 ),
                 entityIdService

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -110,7 +110,8 @@ public class ResponseFactory {
     }
 
     public NonMatchingAssertionService createNonMatchingAssertionService( ExplicitKeySignatureTrustEngine signatureTrustEngine,
-                                                                          DateTimeComparator dateTimeComparator ) {
+                                                                          DateTimeComparator dateTimeComparator,
+                                                                          String hashingEntityId) {
 
         MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(signatureTrustEngine);
         SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
@@ -123,8 +124,8 @@ public class ResponseFactory {
                 new AssertionAttributeStatementValidator(),
                 new AuthnContextFactory(),
                 new VerifyMatchingDatasetUnmarshaller(new AddressFactory()),
-                new AssertionClassifier());
-
+                new AssertionClassifier(),
+                new UserIdHashFactory(hashingEntityId));
     }
 
     private MetadataBackedSignatureValidator createMetadataBackedSignatureValidator( ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine ) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/UserIdHashFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/UserIdHashFactory.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.verifyserviceprovider.factories.saml;
+
+import org.apache.commons.codec.binary.Hex;
+import org.opensaml.security.crypto.JCAConstants;
+import uk.gov.ida.verifyserviceprovider.exceptions.AuthnContextMissingException;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.MessageFormat;
+import java.util.Optional;
+
+
+public class UserIdHashFactory {
+    private final String hashingEntityId;
+
+    public UserIdHashFactory(String hashingEntityId) {
+        this.hashingEntityId = hashingEntityId;
+    }
+
+    public String hashId(String issuerEntityId, String persistentId, Optional<AuthnContext> authnContext) {
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance(JCAConstants.DIGEST_SHA256);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        final String toHash = idToHash(issuerEntityId, persistentId, authnContext);
+
+        try {
+            messageDigest.update(toHash.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+
+        byte[] digest = messageDigest.digest();
+        return Hex.encodeHexString(digest);
+    }
+
+    private String idToHash(String issuerEntityId, String persistentId, Optional<AuthnContext> context) {
+        String persistentIdHash;
+
+        final AuthnContext authnContext = context.orElseThrow(() -> new AuthnContextMissingException(String.format("Authn context absent for persistent id %s", persistentId)));
+        if (authnContext.equals(AuthnContext.LEVEL_2)) {
+            // default behaviour - for LEVEL_2
+            persistentIdHash = MessageFormat.format("{0}{1}{2}", issuerEntityId, hashingEntityId, persistentId);
+        } else {
+            // if we have an authnContext that is not LEVEL_2 then regenerate the hash
+            // this does not break existing behaviour for LEVEL_2 RPs
+            persistentIdHash = MessageFormat.format("{0}{1}{2}{3}", issuerEntityId, hashingEntityId, persistentId, authnContext.name());
+        }
+        return persistentIdHash;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionService.java
@@ -14,6 +14,7 @@ import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier.AssertionType;
+import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 
 import javax.xml.namespace.QName;
@@ -25,6 +26,7 @@ import static java.util.Collections.singletonList;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_PIDS;
 
+
 public class NonMatchingAssertionService implements AssertionService {
 
     private final SamlAssertionsSignatureValidator assertionsSignatureValidator;
@@ -33,6 +35,7 @@ public class NonMatchingAssertionService implements AssertionService {
     private final AuthnContextFactory authnContextFactory;
     private final MatchingDatasetUnmarshaller matchingDatasetUnmarshaller;
     private final AssertionClassifier assertionClassifierService;
+    private final UserIdHashFactory userIdHashFactory;
 
     public NonMatchingAssertionService(
             SamlAssertionsSignatureValidator assertionsSignatureValidator,
@@ -40,13 +43,17 @@ public class NonMatchingAssertionService implements AssertionService {
             AssertionAttributeStatementValidator attributeStatementValidator,
             AuthnContextFactory authnContextFactory,
             MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
-            AssertionClassifier assertionClassifierService) {
+            AssertionClassifier assertionClassifierService,
+            UserIdHashFactory userIdHashFactory) {
+
+
         this.assertionsSignatureValidator = assertionsSignatureValidator;
         this.subjectValidator = subjectValidator;
         this.attributeStatementValidator = attributeStatementValidator;
         this.authnContextFactory = authnContextFactory;
         this.matchingDatasetUnmarshaller = matchingDatasetUnmarshaller;
         this.assertionClassifierService = assertionClassifierService;
+        this.userIdHashFactory = userIdHashFactory;
     }
 
     @Override

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -90,6 +90,7 @@ public class ApplicationConfigurationFeatureTests {
             put("MSA_METADATA_URL", "some-msa-metadata-url");
             put("MSA_ENTITY_ID", "some-msa-entity-id");
             put("SERVICE_ENTITY_IDS", "[\"http://some-service-entity-id\",\"http://some-other-service-entity-id\"]");
+            put("HASHING_ENTITY_ID", "some-hashing-entity-id");
             put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
             put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
@@ -108,6 +109,7 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getMsaMetadata().getExpectedEntityId()).isEqualTo("some-msa-entity-id");
         assertThat(configuration.getMsaMetadata().getUri().toString()).isEqualTo("some-msa-metadata-url");
         assertThat(configuration.getServiceEntityIds()).containsExactly("http://some-service-entity-id", "http://some-other-service-entity-id");
+        assertThat(configuration.getHashingEntityId()).isEqualTo("some-hashing-entity-id");
         assertThat(configuration.getSamlSigningKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_SIGNING_KEY));
         assertThat(configuration.getSamlPrimaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/UserIdHashFactoryTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/UserIdHashFactoryTest.java
@@ -1,0 +1,60 @@
+package unit.uk.gov.ida.verifyserviceprovider.saml;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.verifyserviceprovider.exceptions.AuthnContextMissingException;
+import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistentId;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserIdHashFactoryTest {
+
+    private static final String HASHING_ENTITY_ID = "entity";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private UserIdHashFactory userIdHashFactory = new UserIdHashFactory(HASHING_ENTITY_ID);
+
+    @Test
+    public void shouldPerformHashing() {
+        final PersistentId persistentId = aPersistentId().build();
+        final String issuerId = "partner";
+
+        final String hashedId = userIdHashFactory.hashId(issuerId, persistentId.getNameId(), Optional.of(AuthnContext.LEVEL_2));
+
+        assertThat(hashedId).isEqualTo("a5fbea969c3837a712cbe9e188804796828f369106478e623a436fa07e8fd298");
+    }
+
+    @Test
+    public void shouldGenerateADifferentHashForEveryLevelOfAssurance(){
+        final PersistentId persistentId = aPersistentId().build();
+        final String partnerEntityId = "partner";
+
+        final long numberOfUniqueGeneratedHashedPids = Arrays.stream(AuthnContext.values())
+                .map(authnContext -> userIdHashFactory.hashId(partnerEntityId, persistentId.getNameId(), Optional.of(authnContext)))
+                .distinct()
+                .count();
+
+        assertThat(numberOfUniqueGeneratedHashedPids).isEqualTo(5);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenAuthnContextAbsent() {
+        exception.expect(AuthnContextMissingException.class);
+        exception.expectMessage(String.format("Authn context absent for persistent id %s", "pid"));
+
+        userIdHashFactory.hashId("", "pid", Optional.empty());
+    }
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/NonMatchingAssertionServiceTest.java
@@ -14,7 +14,6 @@ import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.xmlsec.signature.Signature;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
-
 import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
@@ -22,7 +21,6 @@ import uk.gov.ida.saml.core.test.TestCredentialFactory;
 import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
 import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
 import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
-
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
@@ -32,14 +30,15 @@ import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier;
 import uk.gov.ida.verifyserviceprovider.services.NonMatchingAssertionService;
+import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -83,6 +82,9 @@ public class NonMatchingAssertionServiceTest {
     @Mock
     private VerifyMatchingDatasetUnmarshaller verifyMatchingDatasetUnmarshaller;
 
+    @Mock
+    private UserIdHashFactory userIdHashFactory;
+
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -98,8 +100,9 @@ public class NonMatchingAssertionServiceTest {
                 attributeStatementValidator,
                 authnContextFactory,
                 verifyMatchingDatasetUnmarshaller,
-                new AssertionClassifier()
-        );
+                new AssertionClassifier(),
+                userIdHashFactory);
+
         doNothing().when(subjectValidator).validate(any(), any());
         when(hubSignatureValidator.validate(any(), any())).thenReturn(mock(ValidatedAssertions.class));
 

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -29,6 +29,8 @@ serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
 # To use the Verify Service Provider with multiple services, add their entity IDs here, e.g.
 # '["service-one-entity-id", "service-two-entity-id"]'
 
+hashingEntityId: ${HASHING_ENTITY_ID:-}
+
 # Verify Hub Environment. This tells the service provider where the Verify Hub
 # authentication flow begins and where to find the hub metadata the Verify Service
 # Provider consumes to identify the hub.


### PR DESCRIPTION
- We have left some comments on the `VerifyServiceProviderConfigurationTest.java` to make it easier for the reviewer to understand the `hashingEntityId` scenarios. We can remove these before merging.

- Adds the PID hashing functionality to the VSP as it will happen within here as opposed to the MSA for the non-matching journey.

- The VSP has support for multiple entity IDs (multi-tenanted). We therefore need to know which entity ID to use for hashing in the case of multi tenancy.

The longer version:

What it is?
Add hashing of the PIDs in the VSP as the functionality is currently in the MSA. The MSA currently uses its entity ID as part of the hashing algorithm. The VSP has support for multiple entity IDs (multi-tenanted) so we need to decide which one to hash with.

As most multi-tenanted organisations will want a user to have the same hashed PID (so that they have the same primary key in their user database), we will probably want to use a single entity ID from the VSP for hashing.

Decision: we will add a new parameter to the configuration file hashingEntityId that is used when doing the hashing. If there is only one serviceEntityId , hashingEntityId should default to that without the user have to specify it. If there are multiple serviceEntityIds, the user must specify the hashingEntityId

This will allow existing services that have a single MSA instance to specify their MSA entity ID as the hashing entity ID so historical users have their PIDs hashed in the same way.

Why do we need it?
As a Verify, we need to pass the identity to a connecting service and hash the PID so that privacy across the federation is preserved.


This PR was Co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>