### PR TITLE
BAU: Fix deployment

### DIFF
--- a/dev-manifest-multi-tenant.yml
+++ b/dev-manifest-multi-tenant.yml
@@ -5,6 +5,7 @@ applications:
     env:
       CLOCK_SKEW: PT30s
       SERVICE_ENTITY_IDS: '["http://verify-service-provider-dev-service", "http://passport-verify-stub-relying-party-one", "http://passport-verify-stub-relying-party-two"]'
+      HASHING_ENTITY_ID: http://verify-service-provider-dev-service
       VERIFY_ENVIRONMENT: COMPLIANCE_TOOL
       MSA_ENTITY_ID: https://verify-service-provider-stub-msa
       MSA_METADATA_URL: https://verify-service-provider-stub-msa-metadata.cloudapps.digital/metadata.xml


### PR DESCRIPTION
- The deployment for the multi-tenanted VSP failed because there was
  no hashing entity ID but a list of service entity IDs
- This specifies a hashing entity ID so it can correctly run in
  multi-tenanted mode