### PR TITLE
armQw1ue: VSP to validate Level Of Assurance

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -4,7 +4,6 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.core.domain.AddressFactory;
-import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
 import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.deserializers.OpenSamlXMLObjectUnmarshaller;
@@ -34,6 +33,7 @@ import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
 import uk.gov.ida.verifyserviceprovider.validators.AudienceRestrictionValidator;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
 import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
 import uk.gov.ida.verifyserviceprovider.validators.ResponseSizeValidator;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 import uk.gov.ida.verifyserviceprovider.validators.TimeRestrictionValidator;
@@ -144,7 +144,8 @@ public class ResponseFactory {
                 new AssertionAttributeStatementValidator(),
                 new VerifyMatchingDatasetUnmarshaller(new AddressFactory()),
                 new AssertionClassifier(),
-                new MatchingDatasetToNonMatchingAttributesMapper()
+                new MatchingDatasetToNonMatchingAttributesMapper(),
+                new LevelOfAssuranceValidator()
             );
     }
 

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionServiceTest.java
@@ -99,7 +99,7 @@ public class MatchingAssertionServiceTest {
     }
 
     @Test
-    public void shouldtranslateValidAssertion() {
+    public void shouldTranslateValidAssertion() {
         TranslatedResponseBody result = matchingAssertionService.translateSuccessResponse(ImmutableList.of(
             anAssertionWith("some-pid", LEVEL_2_AUTHN_CTX).buildUnencrypted()
         ), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);


### PR DESCRIPTION
https://trello.com/c/armQw1ue/246-vsp-to-validate-level-of-assurance
VSP now validates against Level of Assurance using the LevelOfAssuranceValidator
Added unit tests to prove the correct exceptions are being thrown with the new validation
Added another acceptance test to make sure the correct exception is being thrown if loa returned by idp is too low