### PR TITLE
FIX: Fixed failing tests due to deserialization

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -166,7 +166,7 @@ public class NonMatchingAcceptanceTest {
         Map<String, String> translateResponseRequestData = ImmutableMap.of(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), VERIFIED_USER_ON_SERVICE_WITH_NON_MATCH_SETTING_ID),
             "requestId", requestResponseBody.getRequestId(),
-            "levelOfAssurance", LEVEL_2.name()
+            "levelOfAssurance", LEVEL_1.name()
         );
 
         Response response = client

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAuthnFailedResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAuthnFailedResponseAcceptanceTest.java
@@ -5,11 +5,10 @@ import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
-import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TestTranslatedNonMatchingResponseBody;
 import uk.gov.ida.verifyserviceprovider.rules.VerifyServiceProviderAppRule;
 import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
 import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
@@ -66,7 +65,7 @@ public class NonMatchingAuthnFailedResponseAcceptanceTest {
             .buildPost(json(translateResponseRequestData))
             .invoke();
 
-        TranslatedNonMatchingResponseBody responseContent = response.readEntity(TranslatedNonMatchingResponseBody.class);
+        TestTranslatedNonMatchingResponseBody responseContent = response.readEntity(TestTranslatedNonMatchingResponseBody.class);
 
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
         assertThat(responseContent.getScenario()).isEqualTo(NonMatchingScenario.AUTHENTICATION_FAILED);

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingNoAuthnContextResponseAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingNoAuthnContextResponseAcceptanceTest.java
@@ -5,11 +5,10 @@ import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
-import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TestTranslatedNonMatchingResponseBody;
 import uk.gov.ida.verifyserviceprovider.rules.VerifyServiceProviderAppRule;
 import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
 import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
@@ -66,7 +65,7 @@ public class NonMatchingNoAuthnContextResponseAcceptanceTest {
             .buildPost(json(translateResponseRequestData))
             .invoke();
 
-        TranslatedNonMatchingResponseBody responseContent = response.readEntity(TranslatedNonMatchingResponseBody.class);
+        TestTranslatedNonMatchingResponseBody responseContent = response.readEntity(TestTranslatedNonMatchingResponseBody.class);
 
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
         assertThat(responseContent.getScenario()).isEqualTo(NonMatchingScenario.CANCELLATION);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TestTranslatedNonMatchingResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TestTranslatedNonMatchingResponseBody.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class TestTranslatedNonMatchingResponseBody extends TranslatedNonMatchingResponseBody {
+
+    @JsonCreator
+    public TestTranslatedNonMatchingResponseBody(
+            @JsonProperty("scenario") NonMatchingScenario scenario,
+            @JsonProperty("pid") String pid,
+            @JsonProperty("levelOfAssurance") LevelOfAssurance levelOfAssurance,
+            @JsonProperty("attributes") NonMatchingAttributes attributes
+    ) {
+        super(scenario, pid, levelOfAssurance, attributes);
+    }
+
+    public NonMatchingScenario getScenario() {
+        return super.getScenario();
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public LevelOfAssurance getLevelOfAssurance() {
+        return levelOfAssurance;
+    }
+
+    public Optional<NonMatchingAttributes> getAttributes() {
+        return Optional.ofNullable(attributes);
+    }
+
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
@@ -8,11 +8,11 @@ public class TranslatedNonMatchingResponseBody {
     @JsonProperty("scenario")
     private final NonMatchingScenario scenario;
     @JsonProperty("pid")
-    private final String pid;
+    protected final String pid;
     @JsonProperty("levelOfAssurance")
-    private final LevelOfAssurance levelOfAssurance;
+    protected final LevelOfAssurance levelOfAssurance;
     @JsonProperty("attributes")
-    private final NonMatchingAttributes attributes;
+    protected final NonMatchingAttributes attributes;
 
     public TranslatedNonMatchingResponseBody(
             NonMatchingScenario scenario,
@@ -28,18 +28,6 @@ public class TranslatedNonMatchingResponseBody {
 
     public NonMatchingScenario getScenario() {
         return scenario;
-    }
-
-    public String getPid() {
-        return pid;
-    }
-
-    public LevelOfAssurance getLevelOfAssurance() {
-        return levelOfAssurance;
-    }
-
-    public Optional<NonMatchingAttributes> getAttributes() {
-        return Optional.ofNullable(attributes);
     }
 
     @Override


### PR DESCRIPTION
The TranslatedNonMatchingResponseBody is required by the VSP for deserialization
however when testing it is required to be able to serialise this class. The solution
was to create a test class that inherits TranslatedNonMatchingResponseBody which has
the ability to perform serialisation and use this instead for tests.

Added a TestTranslatedNonMatchingResponseBody

Co-authored-by: olakunle jegede <olakunle.jegede@digital.cabinet-office.gov.uk>