### PR TITLE
JhIrB3HL: eIDAS non matching journey

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
+import keystore.KeyStoreResource;
 import org.json.JSONObject;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
@@ -19,9 +20,12 @@ import java.net.URI;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
+import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolV1InitialisationRequestBuilder.aComplianceToolV1InitialisationRequest;
 
 public class AuthnRequestAcceptanceTest {
@@ -31,6 +35,13 @@ public class AuthnRequestAcceptanceTest {
     private static String HASHING_ENTITY_ID = "http://default-entity-id";
     private static String MULTI_ENTITY_ID_1 = "http://service-entity-id-one";
     private static String MULTI_ENTITY_ID_2 = "http://service-entity-id-two";
+
+    private static final KeyStoreResource KEY_STORE_RESOURCE = aKeyStoreResource()
+        .withCertificate("VERIFY-FEDERATION", aCertificate().withCertificate(METADATA_SIGNING_A_PUBLIC_CERT).build().getCertificate())
+        .build();
+    static {
+        KEY_STORE_RESOURCE.create();
+    }
 
     public static final DropwizardTestSupport<VerifyServiceProviderConfiguration> singleTenantApplication = new DropwizardTestSupport<>(
         VerifyServiceProviderApplication.class,
@@ -43,7 +54,13 @@ public class AuthnRequestAcceptanceTest {
         ConfigOverride.config("hashingEntityId", HASHING_ENTITY_ID),
         ConfigOverride.config("msaMetadata.expectedEntityId", "some-msa-expected-entity-id"),
         ConfigOverride.config("msaMetadata.uri", "http://some-msa-uri"),
-        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)
+        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+        ConfigOverride.config("europeanIdentity.enabled", "false"),
+        ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", KEY_STORE_RESOURCE.getAbsolutePath()),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", KEY_STORE_RESOURCE.getPassword())
     );
 
     public static final DropwizardTestSupport<VerifyServiceProviderConfiguration> multiTenantApplication = new DropwizardTestSupport<>(
@@ -57,7 +74,13 @@ public class AuthnRequestAcceptanceTest {
         ConfigOverride.config("hashingEntityId", HASHING_ENTITY_ID),
         ConfigOverride.config("msaMetadata.expectedEntityId", "some-msa-expected-entity-id"),
         ConfigOverride.config("msaMetadata.uri", "http://some-msa-uri"),
-        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)
+        ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+        ConfigOverride.config("europeanIdentity.enabled", "false"),
+        ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", KEY_STORE_RESOURCE.getAbsolutePath()),
+        ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", KEY_STORE_RESOURCE.getPassword())
     );
 
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
@@ -1,0 +1,88 @@
+package uk.gov.ida.verifyserviceprovider;
+
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+import uk.gov.ida.verifyserviceprovider.dto.TranslateSamlResponseBody;
+import uk.gov.ida.verifyserviceprovider.rules.NonMatchingVerifyServiceProviderAppRule;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_COUNTRY_ONE;
+import static uk.gov.ida.verifyserviceprovider.builders.AssertionHelper.aValidEidasResponse;
+import static uk.gov.ida.verifyserviceprovider.builders.AssertionHelper.anInvalidAssertionSignatureEidasResponse;
+import static uk.gov.ida.verifyserviceprovider.builders.AssertionHelper.anInvalidSignatureEidasResponse;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
+
+public class NonMatchingEidasAcceptanceTest {
+
+    @ClassRule
+    public static NonMatchingVerifyServiceProviderAppRule application = new NonMatchingVerifyServiceProviderAppRule();
+
+    @Test
+    public void shouldProcessEidasResponseCorrectly() throws MarshallingException, SignatureException {
+        String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
+                aValidEidasResponse("requestId", application.getCountryEntityId()).build()
+        );
+        Response response = application.client().target(format("http://localhost:%s/translate-non-matching-response", application.getLocalPort())).request().post(
+                Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
+        );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        JSONObject responseBody = new JSONObject(response.readEntity(String.class));
+        assertThat(responseBody.getString("scenario")).isEqualTo(IDENTITY_VERIFIED.toString());
+        assertThat(responseBody.getString("pid")).isNotBlank();
+        assertThat(responseBody.getString("levelOfAssurance")).isEqualTo(LEVEL_2.toString());
+    }
+
+    @Test
+    public void shouldReturn400WhenResponseContainsInvalidSignature() throws MarshallingException, SignatureException {
+        String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
+                anInvalidSignatureEidasResponse("requestId", application.getCountryEntityId()).build()
+        );
+        Response response = application.client().target(format("http://localhost:%s/translate-non-matching-response", application.getLocalPort())).request().post(
+                Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
+        );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+
+        String responseBody = response.readEntity(String.class);
+        assertThat(responseBody).contains("Signature was not valid.");
+    }
+
+    @Test
+    public void shouldReturn400WhenAssertionContainsInvalidSignature() throws MarshallingException, SignatureException {
+        String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
+                anInvalidAssertionSignatureEidasResponse("requestId", application.getCountryEntityId()).build()
+        );
+        Response response = application.client().target(format("http://localhost:%s/translate-non-matching-response", application.getLocalPort())).request().post(
+                Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
+        );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+
+        String responseBody = response.readEntity(String.class);
+        assertThat(responseBody).contains("Signature was not valid.");
+    }
+
+    @Test
+    public void shouldReturn400WhenAssertionSignedByCountryNotInTrustAnchor() throws MarshallingException, SignatureException {
+        String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
+                aValidEidasResponse("requestId", STUB_COUNTRY_ONE).build()
+        );
+        Response response = application.client().target(format("http://localhost:%s/translate-non-matching-response", application.getLocalPort())).request().post(
+                Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
+        );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
@@ -1,0 +1,180 @@
+package uk.gov.ida.verifyserviceprovider.builders;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Audience;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.impl.AudienceBuilder;
+import org.opensaml.saml.saml2.core.impl.AudienceRestrictionBuilder;
+import org.opensaml.saml.saml2.core.impl.ConditionsBuilder;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder;
+import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
+
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.TestEntityIds.TEST_RP;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anEidasAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SignatureBuilder.aSignature;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+public class AssertionHelper {
+
+    public static EncryptedAssertion anEidasEncryptedAssertion(String requestId, String issuerId, Signature assertionSignature) {
+        return anAssertion()
+            .withSubject(
+                aSubject().withSubjectConfirmation(
+                    aSubjectConfirmation().withSubjectConfirmationData(
+                        aSubjectConfirmationData()
+                            .withInResponseTo(requestId)
+                            .build())
+                        .build())
+                    .build())
+                .withIssuer(
+                    anIssuer()
+                        .withIssuerId(issuerId)
+                        .build())
+                .addAttributeStatement(anEidasAttributeStatement().build())
+                .addAuthnStatement(anEidasAuthnStatement().build())
+                .withSignature(assertionSignature)
+                .withConditions(aConditions())
+                .buildWithEncrypterCredential(
+                    new TestCredentialFactory(
+                        TEST_RP_PUBLIC_ENCRYPTION_CERT,
+                        TEST_RP_PRIVATE_ENCRYPTION_KEY
+                    ).getEncryptingCredential()
+                );
+    }
+
+    public static EncryptedAssertion anEidasEncryptedAssertionWithInvalidSignature(String assertionIssuerId) {
+        return anAssertion()
+            .addAuthnStatement(AuthnStatementBuilder.anAuthnStatement().build())
+            .withIssuer(
+                anIssuer()
+                    .withIssuerId(assertionIssuerId)
+                    .build())
+            .withSignature(aSignature()
+                .withSigningCredential(
+                    new TestCredentialFactory(
+                        TEST_RP_PUBLIC_SIGNING_CERT,
+                        TEST_RP_PRIVATE_SIGNING_KEY
+                    ).getSigningCredential()
+                ).build())
+            .withConditions(aConditions())
+            .buildWithEncrypterCredential(
+                new TestCredentialFactory(
+                    TEST_RP_MS_PUBLIC_ENCRYPTION_CERT,
+                    TEST_RP_MS_PRIVATE_ENCRYPTION_KEY
+                ).getEncryptingCredential()
+            );
+    }
+
+    public static ResponseBuilder aValidEidasResponse(String requestId, String assertionIssuerId) {
+        return ResponseBuilder.aResponse()
+                .withId(requestId)
+                .withInResponseTo(requestId)
+                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                .addEncryptedAssertion(anEidasEncryptedAssertion(requestId, assertionIssuerId, anEidasSignature()))
+                .withSigningCredential(
+                    new TestCredentialFactory(
+                            HUB_TEST_PUBLIC_SIGNING_CERT,
+                            HUB_TEST_PRIVATE_SIGNING_KEY
+                    ).getSigningCredential());
+    }
+
+    public static ResponseBuilder anInvalidSignatureEidasResponse(String requestId, String assertionIssuerId) {
+        return ResponseBuilder.aResponse()
+                .withId(requestId)
+                .withInResponseTo(requestId)
+                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                .addEncryptedAssertion(anEidasEncryptedAssertion(requestId, assertionIssuerId, anEidasSignature()))
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
+                                STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential());
+    }
+
+    public static ResponseBuilder anInvalidAssertionSignatureEidasResponse(String requestId, String assertionIssuerId) {
+        return ResponseBuilder.aResponse()
+                .withId(requestId)
+                .withInResponseTo(requestId)
+                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                .addEncryptedAssertion(anEidasEncryptedAssertion(requestId, assertionIssuerId, anIdpSignature()))
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                HUB_TEST_PUBLIC_SIGNING_CERT,
+                                HUB_TEST_PRIVATE_SIGNING_KEY
+                        ).getSigningCredential());
+    }
+
+    public static Signature anEidasSignature() {
+        return aSignature()
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
+                                STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential()
+                ).build();
+    }
+
+    public static Signature anIdpSignature() {
+        return aSignature()
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                STUB_IDP_PUBLIC_PRIMARY_CERT,
+                                STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential()
+                ).build();
+    }
+
+    private static Subject anAssertionSubject(final String inResponseTo, boolean shouldBeExpired) {
+        final DateTime notOnOrAfter;
+        if (shouldBeExpired) {
+            notOnOrAfter = DateTime.now().minusMinutes(5);
+        } else {
+            notOnOrAfter = DateTime.now().plus(1000000);
+        }
+        return aSubject()
+                .withSubjectConfirmation(
+                        aSubjectConfirmation()
+                                .withSubjectConfirmationData(
+                                        aSubjectConfirmationData()
+                                                .withNotOnOrAfter(notOnOrAfter)
+                                                .withInResponseTo(inResponseTo)
+                                                .build()
+                                ).build()
+                ).build();
+    }
+
+    private static Conditions aConditions() {
+        Conditions conditions = new ConditionsBuilder().buildObject();
+        conditions.setNotBefore(DateTime.now());
+        conditions.setNotOnOrAfter(DateTime.now().plusMinutes(10));
+        AudienceRestriction audienceRestriction= new AudienceRestrictionBuilder().buildObject();
+        Audience audience = new AudienceBuilder().buildObject();
+        audience.setAudienceURI(TEST_RP);
+        audienceRestriction.getAudiences().add(audience);
+        conditions.getAudienceRestrictions().add(audienceRestriction);
+        return conditions;
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
@@ -1,0 +1,161 @@
+package uk.gov.ida.verifyserviceprovider.rules;
+
+import certificates.values.CACertificates;
+import com.nimbusds.jose.JOSEException;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
+import httpstub.HttpStubRule;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import keystore.KeyStoreResource;
+import keystore.builders.KeyStoreResourceBuilder;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.Constants;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.eidas.trustanchor.Generator;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.IdpSsoDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
+import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
+import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
+import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
+
+import javax.ws.rs.core.MediaType;
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static uk.gov.ida.common.shared.security.Certificate.BEGIN_CERT;
+import static uk.gov.ida.common.shared.security.Certificate.END_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.TestEntityIds.TEST_RP;
+import static uk.gov.ida.saml.metadata.ResourceEncoder.entityIdAsResource;
+
+public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServiceProviderConfiguration> {
+
+    private static final String VERIFY_METADATA_PATH = "/verify-metadata";
+    private static final String TRUST_ANCHOR_PATH = "/trust-anchor";
+    private static final String METADATA_AGGREGATOR_PATH = "/metadata-aggregator";
+    private static final String COUNTRY_METADATA_PATH = "/test-country";
+    private static final String METADATA_SOURCE_PATH = "/metadata-source";
+
+    private static final HttpStubRule metadataAggregatorServer = new HttpStubRule();
+    private static final HttpStubRule trustAnchorServer = new HttpStubRule();
+    private static final HttpStubRule verifyMetadataServer = new HttpStubRule();
+    private static final MockMsaServer msaServer = new MockMsaServer();
+    private String countryEntityId;
+
+    private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+    private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+
+    public NonMatchingVerifyServiceProviderAppRule() {
+        super(
+            VerifyServiceProviderApplication.class,
+            "verify-service-provider.yml",
+            ConfigOverride.config("serviceEntityIds", TEST_RP),
+            ConfigOverride.config("hashingEntityId", "some-hashing-entity-id"),
+            ConfigOverride.config("server.connector.port", String.valueOf(0)),
+            ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
+            ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
+            ConfigOverride.config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
+            ConfigOverride.config("verifyHubConfiguration.metadata.uri", () -> "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
+            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
+            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", metadataTrustStore.getPassword()),
+            ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+            ConfigOverride.config("msaMetadata.uri", msaServer::getUri),
+            ConfigOverride.config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID),
+            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", HUB_CONNECTOR_ENTITY_ID),
+            ConfigOverride.config("europeanIdentity.enabled", "true"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://localhost:" + trustAnchorServer.getPort() + TRUST_ANCHOR_PATH),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://localhost:" + metadataAggregatorServer.getPort() + METADATA_SOURCE_PATH),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.store", countryMetadataTrustStore.getAbsolutePath()),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.trustStorePassword", countryMetadataTrustStore.getPassword())
+        );
+    }
+
+    @Override
+    protected void before() {
+        countryMetadataTrustStore.create();
+        metadataTrustStore.create();
+
+        countryEntityId = "https://localhost:12345" + METADATA_AGGREGATOR_PATH + COUNTRY_METADATA_PATH;
+
+        try {
+            InitializationService.initialize();
+            String testCountryMetadata = new MetadataFactory().singleEntityMetadata(buildTestCountryEntityDescriptor());
+
+            msaServer.start();
+            msaServer.serveDefaultMetadata();
+
+            verifyMetadataServer.reset();
+            verifyMetadataServer.register(VERIFY_METADATA_PATH, 200, Constants.APPLICATION_SAMLMETADATA_XML, new MetadataFactory().defaultMetadata());
+
+            trustAnchorServer.reset();
+            trustAnchorServer.register(TRUST_ANCHOR_PATH, 200, MediaType.APPLICATION_OCTET_STREAM, buildTrustAnchorString());
+
+            metadataAggregatorServer.reset();
+            metadataAggregatorServer.register(METADATA_SOURCE_PATH + "/" + entityIdAsResource(countryEntityId), 200, Constants.APPLICATION_SAMLMETADATA_XML, testCountryMetadata);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        super.before();
+    }
+
+    private String buildTrustAnchorString() throws JOSEException, CertificateEncodingException {
+        X509CertificateFactory x509CertificateFactory = new X509CertificateFactory();
+        PrivateKey trustAnchorKey = new PrivateKeyFactory().createPrivateKey(Base64.getDecoder().decode(METADATA_SIGNING_A_PRIVATE_KEY));
+        X509Certificate trustAnchorCert = x509CertificateFactory.createCertificate(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT);
+        Generator generator = new Generator(trustAnchorKey, trustAnchorCert);
+        HashMap<String, List<X509Certificate>> trustAnchorMap = new HashMap<>();
+        X509Certificate metadataCACert = x509CertificateFactory.createCertificate(CACertificates.TEST_METADATA_CA.replace(BEGIN_CERT, "").replace(END_CERT, "").replace("\n", ""));
+        trustAnchorMap.put(countryEntityId, singletonList(metadataCACert));
+        return generator.generateFromMap(trustAnchorMap).serialize();
+    }
+
+    private EntityDescriptor buildTestCountryEntityDescriptor() throws Exception {
+        KeyDescriptor signingKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor()
+                .withX509ForSigning(STUB_COUNTRY_PUBLIC_PRIMARY_CERT)
+                .build();
+
+        IDPSSODescriptor idpSsoDescriptor = IdpSsoDescriptorBuilder.anIdpSsoDescriptor()
+                .withoutDefaultSigningKey()
+                .addKeyDescriptor(signingKeyDescriptor)
+                .build();
+
+        Signature signature = SignatureBuilder.aSignature()
+                .withSigningCredential(new TestCredentialFactory(METADATA_SIGNING_A_PUBLIC_CERT, METADATA_SIGNING_A_PRIVATE_KEY).getSigningCredential())
+                .withX509Data(METADATA_SIGNING_A_PUBLIC_CERT)
+                .build();
+
+        return EntityDescriptorBuilder.anEntityDescriptor()
+                .withEntityId(countryEntityId)
+                .withIdpSsoDescriptor(idpSsoDescriptor)
+                .setAddDefaultSpServiceDescriptor(false)
+                .withValidUntil(DateTime.now().plusWeeks(2))
+                .withSignature(signature)
+                .build();
+    }
+
+    public String getCountryEntityId() {
+        return countryEntityId;
+    }
+}

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
@@ -3,14 +3,26 @@ package uk.gov.ida.verifyserviceprovider.rules;
 import common.uk.gov.ida.verifyserviceprovider.servers.MockMsaServer;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import keystore.KeyStoreResource;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 
+import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 
 public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServiceProviderConfiguration> {
+
+    private static final KeyStoreResource KEY_STORE_RESOURCE = aKeyStoreResource()
+        .withCertificate("VERIFY-FEDERATION", aCertificate().withCertificate(METADATA_SIGNING_A_PUBLIC_CERT).build().getCertificate())
+        .build();
+    static {
+        KEY_STORE_RESOURCE.create();
+    }
+
 
     public VerifyServiceProviderAppRule(MockMsaServer msaServer, String secondaryEncryptionKey, String serviceEntityIdOverride) {
         super(
@@ -29,7 +41,13 @@ public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServic
                 msaServer.serveDefaultMetadata();
                 return msaServer.getUri();
             }),
-            ConfigOverride.config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID)
+            ConfigOverride.config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID),
+            ConfigOverride.config("europeanIdentity.enabled", "false"),
+            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", KEY_STORE_RESOURCE.getAbsolutePath()),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", KEY_STORE_RESOURCE.getPassword())
         );
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
@@ -2,6 +2,7 @@ package uk.gov.ida.verifyserviceprovider;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import io.dropwizard.Application;
+import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
@@ -16,6 +17,7 @@ import uk.gov.ida.verifyserviceprovider.factories.VerifyServiceProviderFactory;
 import uk.gov.ida.verifyserviceprovider.listeners.VerifyServiceProviderServerListener;
 import uk.gov.ida.verifyserviceprovider.utils.ConfigurationFileFinder;
 
+import javax.ws.rs.client.Client;
 import java.util.Arrays;
 
 public class VerifyServiceProviderApplication extends Application<VerifyServiceProviderConfiguration> {
@@ -59,7 +61,8 @@ public class VerifyServiceProviderApplication extends Application<VerifyServiceP
 
     @Override
     public void run(VerifyServiceProviderConfiguration configuration, Environment environment) throws Exception {
-        VerifyServiceProviderFactory factory = new VerifyServiceProviderFactory(configuration, hubMetadataBundle, msaMetadataBundle);
+        Client client = new JerseyClientBuilder(environment).build(getName());
+        VerifyServiceProviderFactory factory = new VerifyServiceProviderFactory(configuration, hubMetadataBundle, msaMetadataBundle, client);
 
         environment.jersey().register(new JerseyViolationExceptionMapper());
         environment.jersey().register(new JsonProcessingExceptionMapper());

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class EuropeanIdentityConfiguration {
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private String hubConnectorEntityId;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private boolean enabled;
+
+    @Valid
+    @JsonProperty
+    private EidasMetadataConfiguration aggregatedMetadata;
+
+    public String getHubConnectorEntityId() {
+        return hubConnectorEntityId;
+    }
+
+    public EidasMetadataConfiguration getAggregatedMetadata() {
+        return aggregatedMetadata;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
@@ -25,6 +25,7 @@ public class VerifyServiceProviderConfiguration extends Configuration {
     private PrivateKey samlSecondaryEncryptionKey;
     private MsaMetadataConfiguration msaMetadata;
     private Duration clockSkew;
+    private EuropeanIdentityConfiguration europeanIdentity;
 
     @JsonCreator
     public VerifyServiceProviderConfiguration(
@@ -35,7 +36,8 @@ public class VerifyServiceProviderConfiguration extends Configuration {
         @JsonProperty("samlPrimaryEncryptionKey") @NotNull @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlPrimaryEncryptionKey,
         @JsonProperty("samlSecondaryEncryptionKey") @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlSecondaryEncryptionKey,
         @JsonProperty("msaMetadata") @NotNull @Valid MsaMetadataConfiguration msaMetadata,
-        @JsonProperty("clockSkew") @NotNull @Valid Duration clockSkew
+        @JsonProperty("clockSkew") @NotNull @Valid Duration clockSkew,
+        @JsonProperty("europeanIdentity") @Valid EuropeanIdentityConfiguration europeanIdentity
     ) {
         this.serviceEntityIds = serviceEntityIds;
         this.hashingEntityId = hashingEntityId;
@@ -45,6 +47,7 @@ public class VerifyServiceProviderConfiguration extends Configuration {
         this.samlSecondaryEncryptionKey = samlSecondaryEncryptionKey;
         this.msaMetadata = msaMetadata;
         this.clockSkew = clockSkew;
+        this.europeanIdentity = europeanIdentity;
     }
 
     public List<String> getServiceEntityIds() {
@@ -87,5 +90,9 @@ public class VerifyServiceProviderConfiguration extends Configuration {
 
     public Duration getClockSkew() {
         return clockSkew;
+    }
+
+    public EuropeanIdentityConfiguration getEuropeanIdentity() {
+        return europeanIdentity;
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -5,24 +5,36 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import org.opensaml.security.crypto.KeySupport;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
+import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.security.MetadataBackedEncryptionCredentialResolver;
 import uk.gov.ida.shared.utils.manifest.ManifestReader;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
 import uk.gov.ida.verifyserviceprovider.healthcheck.MetadataHealthCheck;
 import uk.gov.ida.verifyserviceprovider.resources.GenerateAuthnRequestResource;
 import uk.gov.ida.verifyserviceprovider.resources.TranslateNonMatchingSamlResponseResource;
 import uk.gov.ida.verifyserviceprovider.resources.TranslateSamlResponseResource;
 import uk.gov.ida.verifyserviceprovider.resources.VersionNumberResource;
+import uk.gov.ida.verifyserviceprovider.services.ClassifyingAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.EidasAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
+import uk.gov.ida.verifyserviceprovider.services.IdpAssertionService;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
 
+import javax.ws.rs.client.Client;
 import java.security.KeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.util.List;
+import java.util.Timer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -37,11 +49,13 @@ public class VerifyServiceProviderFactory {
     private final MetadataResolverBundle verifyMetadataBundler;
     private final MetadataResolverBundle msaMetadataBundle;
     private final ManifestReader manifestReader;
+    private final Client client;
 
     public VerifyServiceProviderFactory(
             VerifyServiceProviderConfiguration configuration,
             MetadataResolverBundle verifyMetadataBundler,
-            MetadataResolverBundle msaMetadataBundle) throws KeyException {
+            MetadataResolverBundle msaMetadataBundle,
+            Client client) throws KeyException {
         this.configuration = configuration;
         this.responseFactory = new ResponseFactory(getDecryptionKeyPairs(configuration.getSamlPrimaryEncryptionKey(), configuration.getSamlSecondaryEncryptionKey()));
         this.dateTimeComparator = new DateTimeComparator(configuration.getClockSkew());
@@ -49,6 +63,7 @@ public class VerifyServiceProviderFactory {
         this.verifyMetadataBundler = verifyMetadataBundler;
         this.msaMetadataBundle = msaMetadataBundle;
         this.manifestReader = new ManifestReader();
+        this.client = client;
     }
 
     private List<KeyPair> getDecryptionKeyPairs(PrivateKey primary, PrivateKey secondary) throws KeyException {
@@ -87,7 +102,7 @@ public class VerifyServiceProviderFactory {
         return new TranslateSamlResponseResource(
             responseFactory.createMatchingResponseService(
                 getHubSignatureTrustEngine(),
-                responseFactory.createMsaAssertionService(getMsaSignatureTrustEngine(), dateTimeComparator),
+                responseFactory.createMsaAssertionService(getMsaSignatureTrustEngine(), new SignatureValidatorFactory(), dateTimeComparator),
                 dateTimeComparator
             ),
             entityIdService
@@ -95,13 +110,22 @@ public class VerifyServiceProviderFactory {
     }
 
     public TranslateNonMatchingSamlResponseResource getTranslateNonMatchingSamlResponseResource() {
+        IdpAssertionService idpAssertionService = responseFactory.createIdpAssertionService(
+                getHubSignatureTrustEngine(),
+                new SignatureValidatorFactory(),
+                dateTimeComparator,
+                configuration.getHashingEntityId()
+        );
+
+        EidasAssertionService eidasAssertionService = responseFactory.createEidasAssertionService(
+                dateTimeComparator,
+                getEidasMetadataResolverRepository()
+        );
+
         return new TranslateNonMatchingSamlResponseResource(
                 responseFactory.createNonMatchingResponseService(
                         getHubSignatureTrustEngine(),
-                        responseFactory.createIdpAssertionService(
-                                getHubSignatureTrustEngine(),
-                                dateTimeComparator,
-                                configuration.getHashingEntityId()),
+                        new ClassifyingAssertionService(idpAssertionService, eidasAssertionService),
                         dateTimeComparator
                 ),
                 entityIdService
@@ -129,5 +153,22 @@ public class VerifyServiceProviderFactory {
 
     private ExplicitKeySignatureTrustEngine getMsaSignatureTrustEngine() {
         return msaMetadataBundle.getSignatureTrustEngine();
+    }
+
+    private EidasMetadataResolverRepository getEidasMetadataResolverRepository() {
+        return new EidasMetadataResolverRepository(
+            getEidasTrustAnchorResolver(),
+            configuration.getEuropeanIdentity().getAggregatedMetadata(),
+            new DropwizardMetadataResolverFactory(),
+            new Timer(),
+            new MetadataSignatureTrustEngineFactory(),
+            new MetadataResolverConfigBuilder(),
+            client
+        );
+    }
+
+    public EidasTrustAnchorResolver getEidasTrustAnchorResolver() {
+        EidasMetadataConfiguration metadataConfiguration = configuration.getEuropeanIdentity().getAggregatedMetadata();
+        return new EidasTrustAnchorResolver(metadataConfiguration.getTrustAnchorUri(), client, metadataConfiguration.getTrustStore());
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.verifyserviceprovider.factories;
 
-import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import org.opensaml.security.crypto.KeySupport;
@@ -18,7 +17,6 @@ import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfi
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
-import uk.gov.ida.verifyserviceprovider.healthcheck.MetadataHealthCheck;
 import uk.gov.ida.verifyserviceprovider.resources.GenerateAuthnRequestResource;
 import uk.gov.ida.verifyserviceprovider.resources.TranslateNonMatchingSamlResponseResource;
 import uk.gov.ida.verifyserviceprovider.resources.TranslateSamlResponseResource;
@@ -136,19 +134,12 @@ public class VerifyServiceProviderFactory {
         return new VersionNumberResource(manifestReader);
     }
 
-    private MetadataResolver getHubMetadataResolver() {
-        return verifyMetadataBundler.getMetadataResolver();
-    }
     private ExplicitKeySignatureTrustEngine getHubSignatureTrustEngine() {
         return verifyMetadataBundler.getSignatureTrustEngine();
     }
 
     private MetadataCredentialResolver getHubMetadataCredentialResolver() {
         return verifyMetadataBundler.getMetadataCredentialResolver();
-    }
-
-    private MetadataResolver getMsaMetadataResolver() {
-        return msaMetadataBundle.getMetadataResolver();
     }
 
     private ExplicitKeySignatureTrustEngine getMsaSignatureTrustEngine() {
@@ -167,7 +158,7 @@ public class VerifyServiceProviderFactory {
         );
     }
 
-    public EidasTrustAnchorResolver getEidasTrustAnchorResolver() {
+    private EidasTrustAnchorResolver getEidasTrustAnchorResolver() {
         EidasMetadataConfiguration metadataConfiguration = configuration.getEuropeanIdentity().getAggregatedMetadata();
         return new EidasTrustAnchorResolver(metadataConfiguration.getTrustAnchorUri(), client, metadataConfiguration.getTrustStore());
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -87,7 +87,7 @@ public class VerifyServiceProviderFactory {
         return new TranslateSamlResponseResource(
             responseFactory.createMatchingResponseService(
                 getHubSignatureTrustEngine(),
-                responseFactory.createMatchingAssertionService(getMsaSignatureTrustEngine(), dateTimeComparator),
+                responseFactory.createMsaAssertionService(getMsaSignatureTrustEngine(), dateTimeComparator),
                 dateTimeComparator
             ),
             entityIdService
@@ -98,7 +98,7 @@ public class VerifyServiceProviderFactory {
         return new TranslateNonMatchingSamlResponseResource(
                 responseFactory.createNonMatchingResponseService(
                         getHubSignatureTrustEngine(),
-                        responseFactory.createNonMatchingAssertionService(
+                        responseFactory.createIdpAssertionService(
                                 getHubSignatureTrustEngine(),
                                 dateTimeComparator,
                                 configuration.getHashingEntityId()),

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -25,8 +25,8 @@ import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier;
 import uk.gov.ida.verifyserviceprovider.services.AssertionService;
-import uk.gov.ida.verifyserviceprovider.services.MatchingAssertionService;
-import uk.gov.ida.verifyserviceprovider.services.NonMatchingAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.MsaAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.IdpAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.ResponseService;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
 import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
@@ -108,7 +108,7 @@ public class ResponseFactory {
         );
     }
 
-    public MatchingAssertionService createMatchingAssertionService(
+    public MsaAssertionService createMsaAssertionService(
             ExplicitKeySignatureTrustEngine signatureTrustEngine,
             DateTimeComparator dateTimeComparator
     ) {
@@ -123,22 +123,22 @@ public class ResponseFactory {
                 new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator())
         );
 
-        return new MatchingAssertionService(
+        return new MsaAssertionService(
                 assertionValidator,
                 assertionsSignatureValidator
         );
     }
 
-    public NonMatchingAssertionService createNonMatchingAssertionService( ExplicitKeySignatureTrustEngine signatureTrustEngine,
-                                                                          DateTimeComparator dateTimeComparator,
-                                                                          String hashingEntityId) {
+    public IdpAssertionService createIdpAssertionService(ExplicitKeySignatureTrustEngine signatureTrustEngine,
+                                                         DateTimeComparator dateTimeComparator,
+                                                         String hashingEntityId) {
 
         MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(signatureTrustEngine);
         SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
 
-        return new NonMatchingAssertionService(
+        return new IdpAssertionService(
                 new SamlAssertionsSignatureValidator(samlMessageSignatureValidator),
                 new SubjectValidator(timeRestrictionValidator),
                 new AssertionAttributeStatementValidator(),

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -4,6 +4,7 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.transformers.EidasMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.deserializers.OpenSamlXMLObjectUnmarshaller;
@@ -11,6 +12,7 @@ import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 import uk.gov.ida.saml.deserializers.validators.Base64StringDecoder;
 import uk.gov.ida.saml.deserializers.validators.NotNullSamlStringValidator;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.DecrypterFactory;
 import uk.gov.ida.saml.security.IdaKeyStore;
@@ -25,6 +27,7 @@ import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier;
 import uk.gov.ida.verifyserviceprovider.services.AssertionService;
+import uk.gov.ida.verifyserviceprovider.services.EidasAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.MsaAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.IdpAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.ResponseService;
@@ -40,6 +43,7 @@ import uk.gov.ida.verifyserviceprovider.validators.TimeRestrictionValidator;
 
 import java.security.KeyPair;
 import java.util.List;
+import java.util.Optional;
 
 public class ResponseFactory {
 
@@ -110,13 +114,12 @@ public class ResponseFactory {
 
     public MsaAssertionService createMsaAssertionService(
             ExplicitKeySignatureTrustEngine signatureTrustEngine,
+            SignatureValidatorFactory signatureValidatorFactory,
             DateTimeComparator dateTimeComparator
     ) {
-        MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(signatureTrustEngine);
-        SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
-        SamlAssertionsSignatureValidator assertionsSignatureValidator = new SamlAssertionsSignatureValidator(samlMessageSignatureValidator);
+        Optional<SamlAssertionsSignatureValidator> assertionsSignatureValidator = signatureValidatorFactory.getSignatureValidator(Optional.of(signatureTrustEngine));
         AssertionValidator assertionValidator = new AssertionValidator(
                 new InstantValidator(dateTimeComparator),
                 new SubjectValidator(timeRestrictionValidator),
@@ -125,21 +128,20 @@ public class ResponseFactory {
 
         return new MsaAssertionService(
                 assertionValidator,
-                assertionsSignatureValidator
+                new LevelOfAssuranceValidator(),
+                assertionsSignatureValidator.orElseThrow(() -> new RuntimeException("Cannot create MSA signature validator"))
         );
     }
 
     public IdpAssertionService createIdpAssertionService(ExplicitKeySignatureTrustEngine signatureTrustEngine,
+                                                         SignatureValidatorFactory signatureValidatorFactory,
                                                          DateTimeComparator dateTimeComparator,
                                                          String hashingEntityId) {
 
-        MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(signatureTrustEngine);
-        SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
-
         return new IdpAssertionService(
-                new SamlAssertionsSignatureValidator(samlMessageSignatureValidator),
+                signatureValidatorFactory.getSignatureValidator(Optional.of(signatureTrustEngine)).orElseThrow(() -> new RuntimeException("cannot create")),
                 new SubjectValidator(timeRestrictionValidator),
                 new AssertionAttributeStatementValidator(),
                 new VerifyMatchingDatasetUnmarshaller(new AddressFactory()),
@@ -148,6 +150,24 @@ public class ResponseFactory {
                 new LevelOfAssuranceValidator(),
                 new UserIdHashFactory(hashingEntityId)
             );
+    }
+
+    public EidasAssertionService createEidasAssertionService(
+            DateTimeComparator dateTimeComparator,
+            EidasMetadataResolverRepository eidasMetadataResolverRepository
+    ) {
+        TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
+        AudienceRestrictionValidator audienceRestrictionValidator = new AudienceRestrictionValidator();
+
+        return new EidasAssertionService(
+                new SubjectValidator(timeRestrictionValidator),
+                new EidasMatchingDatasetUnmarshaller(),
+                new MatchingDatasetToNonMatchingAttributesMapper(),
+                new InstantValidator(dateTimeComparator),
+                new ConditionsValidator(timeRestrictionValidator, audienceRestrictionValidator),
+                new LevelOfAssuranceValidator(),
+                eidasMetadataResolverRepository,
+                new SignatureValidatorFactory());
     }
 
     private MetadataBackedSignatureValidator createMetadataBackedSignatureValidator( ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine ) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/SignatureValidatorFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/SignatureValidatorFactory.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.verifyserviceprovider.factories.saml;
+
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+
+import java.util.Optional;
+
+public class SignatureValidatorFactory {
+    public Optional<SamlAssertionsSignatureValidator> getSignatureValidator(Optional<ExplicitKeySignatureTrustEngine> trustEngine) {
+        return trustEngine
+            .map(MetadataBackedSignatureValidator::withoutCertificateChainValidation)
+            .map(SamlMessageSignatureValidator::new)
+            .map(SamlAssertionsSignatureValidator::new);
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionServiceV2.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionServiceV2.java
@@ -1,0 +1,79 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+
+public abstract class AssertionServiceV2 implements AssertionService<TranslatedNonMatchingResponseBody> {
+
+    protected final SubjectValidator subjectValidator;
+    private final MatchingDatasetUnmarshaller matchingDatasetUnmarshaller;
+    private final MatchingDatasetToNonMatchingAttributesMapper mdsMapper;
+
+
+    public AssertionServiceV2(
+            SubjectValidator subjectValidator,
+            MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
+            MatchingDatasetToNonMatchingAttributesMapper mdsMapper
+    ) {
+        this.subjectValidator = subjectValidator;
+        this.matchingDatasetUnmarshaller = matchingDatasetUnmarshaller;
+        this.mdsMapper = mdsMapper;
+    }
+
+
+    @Override
+    public TranslatedNonMatchingResponseBody translateNonSuccessResponse(StatusCode statusCode) {
+        Optional.ofNullable(statusCode.getStatusCode())
+            .orElseThrow(() -> new SamlResponseValidationException("Missing status code for non-Success response"));
+        String subStatus = statusCode.getStatusCode().getValue();
+
+        switch (subStatus) {
+            case StatusCode.REQUESTER:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.REQUEST_ERROR, null, null, null);
+            case StatusCode.NO_AUTHN_CONTEXT:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.CANCELLATION, null, null, null);
+            case StatusCode.AUTHN_FAILED:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.AUTHENTICATION_FAILED, null, null, null);
+            default:
+                throw new SamlResponseValidationException(String.format("Unknown SAML sub-status: %s", subStatus));
+        }
+    }
+
+    protected NonMatchingAttributes translateAttributes(Assertion mdsAssertion) {
+        MatchingDataset matchingDataset = matchingDatasetUnmarshaller.fromAssertion(mdsAssertion);
+
+        return mdsMapper.mapToNonMatchingAttributes(matchingDataset);
+    }
+
+    protected String getNameIdFrom(Assertion assertion) {
+        return assertion.getSubject().getNameID().getValue();
+    }
+
+    protected AuthnStatement getAuthnStatementFrom(Assertion assertion) {
+        return assertion.getAuthnStatements().get(0);
+    }
+
+    protected String extractLevelOfAssuranceUriFrom(Assertion assertion) {
+        AuthnStatement authnStatement = getAuthnStatementFrom(assertion);
+        return ofNullable(authnStatement.getAuthnContext())
+            .map(AuthnContext::getAuthnContextClassRef)
+            .map(AuthnContextClassRef::getAuthnContextClassRef)
+            .orElseThrow(() -> new SamlResponseValidationException("Expected a level of assurance."));
+    }
+
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionService.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ClassifyingAssertionService implements AssertionService<TranslatedNonMatchingResponseBody> {
+
+    private final IdpAssertionService idpAssertionService;
+    private final EidasAssertionService eidasAssertionService;
+
+
+    public ClassifyingAssertionService(
+            IdpAssertionService idpAssertionService,
+            EidasAssertionService eidasAssertionService
+    ) {
+        this.idpAssertionService = idpAssertionService;
+        this.eidasAssertionService = eidasAssertionService;
+    }
+
+
+    @Override
+    public TranslatedNonMatchingResponseBody translateSuccessResponse(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
+        AssertionServiceV2 assertionService = isCountryAttributeQuery(assertions) ? eidasAssertionService : idpAssertionService;
+
+        return assertionService.translateSuccessResponse(assertions, expectedInResponseTo, expectedLevelOfAssurance, entityId);
+    }
+
+    @Override
+    public TranslatedNonMatchingResponseBody translateNonSuccessResponse(StatusCode statusCode) {
+        Optional.ofNullable(statusCode.getStatusCode())
+            .orElseThrow(() -> new SamlResponseValidationException("Missing status code for non-Success response"));
+        String subStatus = statusCode.getStatusCode().getValue();
+
+        switch (subStatus) {
+            case StatusCode.REQUESTER:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.REQUEST_ERROR, null, null, null);
+            case StatusCode.NO_AUTHN_CONTEXT:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.CANCELLATION, null, null, null);
+            case StatusCode.AUTHN_FAILED:
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.AUTHENTICATION_FAILED, null, null, null);
+            default:
+                throw new SamlResponseValidationException(String.format("Unknown SAML sub-status: %s", subStatus));
+        }
+    }
+
+
+    private boolean isCountryAttributeQuery(List<Assertion> assertions) {
+        return assertions.stream().anyMatch(eidasAssertionService::isCountryAssertion);
+    }
+
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionService.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
+import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.metadata.MetadataResolverRepository;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
+
+public class EidasAssertionService extends AssertionServiceV2 {
+
+    private final InstantValidator instantValidator;
+    private final ConditionsValidator conditionsValidator;
+    private final LevelOfAssuranceValidator levelOfAssuranceValidator;
+    private final MetadataResolverRepository metadataResolverRepository;
+    private final SignatureValidatorFactory signatureValidatorFactory;
+
+
+    public EidasAssertionService(
+            SubjectValidator subjectValidator,
+            MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
+            MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
+            InstantValidator instantValidator,
+            ConditionsValidator conditionsValidator,
+            LevelOfAssuranceValidator levelOfAssuranceValidator,
+            MetadataResolverRepository metadataResolverRepository,
+            SignatureValidatorFactory signatureValidatorFactory) {
+        super(subjectValidator, matchingDatasetUnmarshaller, mdsMapper);
+        this.instantValidator = instantValidator;
+        this.conditionsValidator = conditionsValidator;
+        this.levelOfAssuranceValidator = levelOfAssuranceValidator;
+        this.metadataResolverRepository = metadataResolverRepository;
+        this.signatureValidatorFactory = signatureValidatorFactory;
+    }
+
+
+    @Override
+    public TranslatedNonMatchingResponseBody translateSuccessResponse(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
+        if (assertions.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one country assertion is expected.");
+        }
+
+        Assertion countryAssertion = assertions.get(0);
+
+        validateCountryAssertion(countryAssertion, expectedInResponseTo, entityId);
+
+        LevelOfAssurance levelOfAssurance = extractLevelOfAssuranceFrom(countryAssertion);
+        levelOfAssuranceValidator.validate(levelOfAssurance, expectedLevelOfAssurance);
+
+        String nameID = getNameIdFrom(countryAssertion);
+
+        NonMatchingAttributes attributes = translateAttributes(countryAssertion);
+
+        return new TranslatedNonMatchingResponseBody(IDENTITY_VERIFIED, nameID, levelOfAssurance, attributes);
+    }
+
+    private void validateCountryAssertion(Assertion assertion, String expectedInResponseTo, String entityId) {
+        signatureValidatorFactory.getSignatureValidator(metadataResolverRepository.getSignatureTrustEngine(assertion.getIssuer().getValue()))
+                .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
+                .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
+        subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
+        conditionsValidator.validate(assertion.getConditions(), entityId);
+    }
+
+    public LevelOfAssurance extractLevelOfAssuranceFrom(Assertion countryAssertion) {
+        String levelOfAssuranceString = extractLevelOfAssuranceUriFrom(countryAssertion);
+
+        try {
+            return LevelOfAssurance.fromSamlValue(new AuthnContextFactory().mapFromEidasToLoA(levelOfAssuranceString).getUri());
+        } catch (Exception ex) {
+            throw new SamlResponseValidationException(String.format("Level of assurance '%s' is not supported.", levelOfAssuranceString));
+        }
+    }
+
+    public Boolean isCountryAssertion(Assertion assertion) {
+        return metadataResolverRepository.getResolverEntityIds().contains(assertion.getIssuer().getValue());
+    }
+
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
@@ -2,12 +2,9 @@ package uk.gov.ida.verifyserviceprovider.services;
 
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.core.AuthnContext;
-import org.opensaml.saml.saml2.core.AuthnContextClassRef;
-import org.opensaml.saml.saml2.core.AuthnStatement;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
-import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
@@ -22,26 +19,23 @@ import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier.AssertionTy
 import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 import javax.xml.namespace.QName;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.Collection;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import static java.util.Collections.singletonList;
-import static java.util.Optional.ofNullable;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS;
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_PIDS;
 import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
 
-public class IdpAssertionService implements AssertionService<TranslatedNonMatchingResponseBody> {
+public class IdpAssertionService extends AssertionServiceV2 {
 
     private final SamlAssertionsSignatureValidator assertionsSignatureValidator;
-    private final SubjectValidator subjectValidator;
     private final AssertionAttributeStatementValidator attributeStatementValidator;
-    private final MatchingDatasetUnmarshaller matchingDatasetUnmarshaller;
     private final AssertionClassifier assertionClassifierService;
-    private final MatchingDatasetToNonMatchingAttributesMapper mdsMapper;
     private final LevelOfAssuranceValidator levelOfAssuranceValidator;
     private UserIdHashFactory userIdHashFactory;
 
@@ -53,13 +47,12 @@ public class IdpAssertionService implements AssertionService<TranslatedNonMatchi
             AssertionClassifier assertionClassifierService,
             MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
             LevelOfAssuranceValidator levelOfAssuranceValidator,
-            UserIdHashFactory userIdHashFactory) {
+            UserIdHashFactory userIdHashFactory
+    ) {
+        super(subjectValidator, matchingDatasetUnmarshaller, mdsMapper);
         this.assertionsSignatureValidator = assertionsSignatureValidator;
-        this.subjectValidator = subjectValidator;
         this.attributeStatementValidator = attributeStatementValidator;
-        this.matchingDatasetUnmarshaller = matchingDatasetUnmarshaller;
         this.assertionClassifierService = assertionClassifierService;
-        this.mdsMapper = mdsMapper;
         this.levelOfAssuranceValidator = levelOfAssuranceValidator;
         this.userIdHashFactory = userIdHashFactory;
     }
@@ -74,11 +67,12 @@ public class IdpAssertionService implements AssertionService<TranslatedNonMatchi
 
         validate(authnAssertion, mdsAssertion, expectedInResponseTo, expectedLevelOfAssurance, levelOfAssurance);
 
-        String nameID = mdsAssertion.getSubject().getNameID().getValue();
+        String nameID = getNameIdFrom(mdsAssertion);
         String issuerID = mdsAssertion.getIssuer().getValue();
-        String uri =  extractLevelOfAssuranceUri(authnAssertion);
+        String levelOfAssuranceUri =  extractLevelOfAssuranceUriFrom(authnAssertion);
+        Optional<AuthnContext> authnContext = getAuthnContext(levelOfAssuranceUri);
 
-        String hashId = userIdHashFactory.hashId(issuerID, nameID, getAuthnContext(uri));
+        String hashId = userIdHashFactory.hashId(issuerID, nameID, authnContext);
 
         NonMatchingAttributes attributes = translateAttributes(mdsAssertion);
 
@@ -150,13 +144,6 @@ public class IdpAssertionService implements AssertionService<TranslatedNonMatchi
     }
 
 
-    public NonMatchingAttributes translateAttributes(Assertion mdsAssertion) {
-        MatchingDataset matchingDataset = matchingDatasetUnmarshaller.fromAssertion(mdsAssertion);
-
-        return mdsMapper.mapToNonMatchingAttributes(matchingDataset);
-    }
-
-
     private Assertion getAuthnAssertion(Collection<Assertion> assertions) {
         Map<AssertionType, List<Assertion>> assertionMap = assertions.stream()
                 .collect(Collectors.groupingBy(assertionClassifierService::classifyAssertion));
@@ -181,27 +168,19 @@ public class IdpAssertionService implements AssertionService<TranslatedNonMatchi
         return mdsAssertions.get(0);
     }
 
+    private Optional<uk.gov.ida.saml.core.domain.AuthnContext> getAuthnContext(String uri) {
+        return Arrays.stream(uk.gov.ida.saml.core.domain.AuthnContext.values())
+                .filter(ctx -> uri.equals(ctx.getUri()))
+                .findFirst();
+    }
+
     public LevelOfAssurance extractLevelOfAssuranceFrom(Assertion authnAssertion) {
-        String levelOfAssuranceUri = extractLevelOfAssuranceUri(authnAssertion);
+        String levelOfAssuranceUri = extractLevelOfAssuranceUriFrom(authnAssertion);
 
         try {
             return LevelOfAssurance.fromSamlValue(levelOfAssuranceUri);
         } catch (Exception ex) {
             throw new SamlResponseValidationException(String.format("Level of assurance '%s' is not supported.", levelOfAssuranceUri));
         }
-    }
-
-    private  Optional<uk.gov.ida.saml.core.domain.AuthnContext>  getAuthnContext(String uri) {
-        return Arrays.stream(uk.gov.ida.saml.core.domain.AuthnContext.values())
-                .filter(ctx -> uri.equals(ctx.getUri()))
-                .findFirst();
-    }
-
-    private String extractLevelOfAssuranceUri(Assertion authnAssertion) {
-        AuthnStatement authnStatement = authnAssertion.getAuthnStatements().get(0);
-        return ofNullable(authnStatement.getAuthnContext())
-                .map(AuthnContext::getAuthnContextClassRef)
-                .map(AuthnContextClassRef::getAuthnContextClassRef)
-                .orElseThrow(() -> new SamlResponseValidationException("Expected a level of assurance."));
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
@@ -34,7 +34,7 @@ import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidation
 import static uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification.MISMATCHED_PIDS;
 import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
 
-public class NonMatchingAssertionService implements AssertionService<TranslatedNonMatchingResponseBody> {
+public class IdpAssertionService implements AssertionService<TranslatedNonMatchingResponseBody> {
 
     private final SamlAssertionsSignatureValidator assertionsSignatureValidator;
     private final SubjectValidator subjectValidator;
@@ -45,7 +45,7 @@ public class NonMatchingAssertionService implements AssertionService<TranslatedN
     private final LevelOfAssuranceValidator levelOfAssuranceValidator;
     private UserIdHashFactory userIdHashFactory;
 
-    public NonMatchingAssertionService(
+    public IdpAssertionService(
             SamlAssertionsSignatureValidator assertionsSignatureValidator,
             SubjectValidator subjectValidator,
             AssertionAttributeStatementValidator attributeStatementValidator,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/MsaAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/MsaAssertionService.java
@@ -23,13 +23,13 @@ import static java.util.Optional.ofNullable;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.ACCOUNT_CREATION;
 import static uk.gov.ida.verifyserviceprovider.dto.Scenario.SUCCESS_MATCH;
 
-public class MatchingAssertionService implements AssertionService<TranslatedResponseBody> {
+public class MsaAssertionService implements AssertionService<TranslatedResponseBody> {
 
 
     private AssertionValidator assertionValidator;
     private SamlAssertionsSignatureValidator assertionsSignatureValidator;
 
-    public MatchingAssertionService( AssertionValidator assertionValidator, SamlAssertionsSignatureValidator assertionsSignatureValidator ) {
+    public MsaAssertionService(AssertionValidator assertionValidator, SamlAssertionsSignatureValidator assertionsSignatureValidator ) {
         this.assertionValidator = assertionValidator;
         this.assertionsSignatureValidator = assertionsSignatureValidator;
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/MsaAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/MsaAssertionService.java
@@ -27,10 +27,14 @@ public class MsaAssertionService implements AssertionService<TranslatedResponseB
 
 
     private AssertionValidator assertionValidator;
+    private LevelOfAssuranceValidator levelOfAssuranceValidator;
     private SamlAssertionsSignatureValidator assertionsSignatureValidator;
 
-    public MsaAssertionService(AssertionValidator assertionValidator, SamlAssertionsSignatureValidator assertionsSignatureValidator ) {
+    public MsaAssertionService(AssertionValidator assertionValidator,
+                               LevelOfAssuranceValidator levelOfAssuranceValidator,
+                               SamlAssertionsSignatureValidator assertionsSignatureValidator) {
         this.assertionValidator = assertionValidator;
+        this.levelOfAssuranceValidator = levelOfAssuranceValidator;
         this.assertionsSignatureValidator = assertionsSignatureValidator;
     }
 
@@ -51,7 +55,6 @@ public class MsaAssertionService implements AssertionService<TranslatedResponseB
         //  3. validate levelOfAssurance
         AuthnStatement authnStatement = assertion.getAuthnStatements().get(0);
         LevelOfAssurance levelOfAssurance = extractLevelOfAssurance(authnStatement);
-        LevelOfAssuranceValidator levelOfAssuranceValidator = new LevelOfAssuranceValidator();
         levelOfAssuranceValidator.validate(levelOfAssurance, expectedLevelOfAssurance);
         //  4. translateAssertions
         String nameID = assertion.getSubject().getNameID().getValue();

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -38,7 +38,13 @@ public class ApplicationConfigurationFeatureTests {
             "verify-service-provider.yml",
             ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
             ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", keyStoreResource.getAbsolutePath()),
-            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", keyStoreResource.getPassword())
+            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", keyStoreResource.getPassword()),
+            ConfigOverride.config("europeanIdentity.enabled", "false"),
+            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", keyStoreResource.getAbsolutePath()),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", keyStoreResource.getPassword())
         );
     }
 

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HubMetadataFeatureTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HubMetadataFeatureTest.java
@@ -74,7 +74,13 @@ public class HubMetadataFeatureTest {
             config("verifyHubConfiguration.metadata.trustStore.password", verifyHubKeystoreResource.getPassword()),
             config("serviceEntityIds", "[\"http://some-service-entity-id\"]"),
             config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
-            config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)
+            config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
+            config("europeanIdentity.enabled", "false"),
+            config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+            config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+            config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+            config("europeanIdentity.aggregatedMetadata.trustStore.path", verifyHubKeystoreResource.getAbsolutePath()),
+            config("europeanIdentity.aggregatedMetadata.trustStore.password", verifyHubKeystoreResource.getPassword())
         );
     }
 

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
@@ -67,7 +67,13 @@ public class MsaMetadataFeatureTest {
             config("verifyHubConfiguration.metadata.expectedEntityId", HUB_ENTITY_ID),
             config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID),
             config("verifyHubConfiguration.metadata.trustStore.path", verifyHubKeystoreResource.getAbsolutePath()),
-            config("verifyHubConfiguration.metadata.trustStore.password", verifyHubKeystoreResource.getPassword())
+            config("verifyHubConfiguration.metadata.trustStore.password", verifyHubKeystoreResource.getPassword()),
+            config("europeanIdentity.enabled", "false"),
+            config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+            config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+            config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+            config("europeanIdentity.aggregatedMetadata.trustStore.path", verifyHubKeystoreResource.getAbsolutePath()),
+            config("europeanIdentity.aggregatedMetadata.trustStore.password", verifyHubKeystoreResource.getPassword())
         );
 
         environmentHelper.setEnv(new HashMap<String, String>() {{

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
@@ -10,6 +10,7 @@ import org.joda.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import uk.gov.ida.verifyserviceprovider.configuration.EuropeanIdentityConfiguration;
 import uk.gov.ida.verifyserviceprovider.configuration.MsaMetadataConfiguration;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyHubConfiguration;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
@@ -57,6 +58,12 @@ public class VerifyServiceProviderConfigurationTest {
             put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
             put("CLOCK_SKEW", "PT30s");
+            put("EUROPEAN_IDENTITY_ENABLED", "false");
+            put("HUB_CONNECTOR_ENTITY_ID", "etc");
+            put("TRUST_ANCHOR_URI", "etc");
+            put("METADATA_SOURCE_URI", "etc");
+            put("TRUSTSTORE_PATH", "etc");
+            put("TRUSTSTORE_PASSWORD", "etc");
         }});
 
         factory.build(
@@ -126,7 +133,8 @@ public class VerifyServiceProviderConfigurationTest {
                 mock(PrivateKey.class),
                 mock(PrivateKey.class),
                 mock(MsaMetadataConfiguration.class),
-                new Duration(1000L)
+                new Duration(1000L),
+                mock(EuropeanIdentityConfiguration.class)
         );
     }
 

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionServiceTest.java
@@ -1,0 +1,83 @@
+package unit.uk.gov.ida.verifyserviceprovider.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.services.ClassifyingAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.EidasAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.IdpAssertionService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ClassifyingAssertionServiceTest {
+
+    private ClassifyingAssertionService classifyingAssertionService;
+
+    @Mock
+    private IdpAssertionService idpAssertionService;
+
+    @Mock
+    private EidasAssertionService eidasAssertionService;
+
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        classifyingAssertionService = new ClassifyingAssertionService(
+                idpAssertionService,
+                eidasAssertionService
+        );
+    }
+
+    @Test
+    public void shouldUseIdpAssertionServiceIfNoAssertionIsACountryAttributeQuery() {
+        Assertion assertion1 = mock(Assertion.class);
+        Assertion assertion2 = mock(Assertion.class);
+        List<Assertion> assertions = Arrays.asList(assertion1, assertion2);
+        String expectedInResponseTo = "somesuch";
+        LevelOfAssurance loa = LevelOfAssurance.LEVEL_2;
+        String entityId = "someEntityId";
+        TranslatedNonMatchingResponseBody expectedResult = mock(TranslatedNonMatchingResponseBody.class);
+
+        when(eidasAssertionService.isCountryAssertion(any())).thenReturn(false);
+        when(idpAssertionService.translateSuccessResponse(assertions, expectedInResponseTo, loa, entityId)).thenReturn(expectedResult);
+
+
+        TranslatedNonMatchingResponseBody actualResult = classifyingAssertionService.translateSuccessResponse(assertions, expectedInResponseTo, loa, entityId);
+
+
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void shouldUseEidasAssertionServiceIfAnyAssertionIsACountryAttributeQuery() {
+        Assertion assertion1 = mock(Assertion.class);
+        Assertion assertion2 = mock(Assertion.class);
+        List<Assertion> assertions = Arrays.asList(assertion1, assertion2);
+        String expectedInResponseTo = "somesuch";
+        LevelOfAssurance loa = LevelOfAssurance.LEVEL_2;
+        String entityId = "someEntityId";
+        TranslatedNonMatchingResponseBody expectedResult = mock(TranslatedNonMatchingResponseBody.class);
+
+        when(eidasAssertionService.isCountryAssertion(assertion1)).thenReturn(false);
+        when(eidasAssertionService.isCountryAssertion(assertion2)).thenReturn(true);
+        when(eidasAssertionService.translateSuccessResponse(assertions, expectedInResponseTo, loa, entityId)).thenReturn(expectedResult);
+
+
+        TranslatedNonMatchingResponseBody actualResult = classifyingAssertionService.translateSuccessResponse(assertions, expectedInResponseTo, loa, entityId);
+
+
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionServiceTest.java
@@ -1,0 +1,176 @@
+package unit.uk.gov.ida.verifyserviceprovider.services;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.transformers.EidasMatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.metadata.MetadataResolverRepository;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.services.EidasAssertionService;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.ida.saml.core.extensions.EidasAuthnContext.EIDAS_LOA_HIGH;
+import static uk.gov.ida.saml.core.extensions.EidasAuthnContext.EIDAS_LOA_SUBSTANTIAL;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_COUNTRY_ONE;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.IPAddressAttributeBuilder.anIPAddress;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+public class EidasAssertionServiceTest {
+
+    private EidasAssertionService eidasAssertionService;
+
+    @Mock
+    private SubjectValidator subjectValidator;
+
+    @Mock
+    private EidasMatchingDatasetUnmarshaller eidasMatchingDatasetUnmarshaller;
+
+    @Mock
+    private MatchingDatasetToNonMatchingAttributesMapper mdsMapper;
+
+    @Mock
+    private InstantValidator instantValidator;
+
+    @Mock
+    private ConditionsValidator conditionsValidator;
+
+    @Mock
+    private LevelOfAssuranceValidator levelOfAssuranceValidator;
+
+    @Mock
+    private MetadataResolverRepository metadataResolverRepository;
+
+    @Mock
+    private SignatureValidatorFactory signatureValidatorFactory;
+
+    @Mock
+    private SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+
+    @Before
+    public void setUp() {
+        IdaSamlBootstrap.bootstrap();
+        initMocks(this);
+        eidasAssertionService = new EidasAssertionService(
+            subjectValidator,
+            eidasMatchingDatasetUnmarshaller,
+            mdsMapper,
+            instantValidator,
+            conditionsValidator,
+            levelOfAssuranceValidator,
+            metadataResolverRepository,
+            signatureValidatorFactory);
+        doNothing().when(instantValidator).validate(any(), any());
+        doNothing().when(subjectValidator).validate(any(), any());
+        doNothing().when(conditionsValidator).validate(any(), any());
+        doNothing().when(levelOfAssuranceValidator).validate(any(), any());
+        when(metadataResolverRepository.getResolverEntityIds()).thenReturn(asList(STUB_COUNTRY_ONE));
+        when(signatureValidatorFactory.getSignatureValidator(any())).thenReturn(Optional.of(samlAssertionsSignatureValidator));
+        when(samlAssertionsSignatureValidator.validate(any(), any())).thenReturn(null);
+        when(mdsMapper.mapToNonMatchingAttributes(any())).thenReturn(mock(NonMatchingAttributes.class));
+    }
+
+    @Test
+    public void shouldCallValidatorsCorrectly() {
+        List<Assertion> assertions = asList(
+            anAssertionWithAuthnStatement(EIDAS_LOA_HIGH, "requestId").buildUnencrypted());
+
+        eidasAssertionService.translateSuccessResponse(assertions, "requestId", LevelOfAssurance.LEVEL_2, null);
+        verify(instantValidator, times(1)).validate(any(), any());
+        verify(subjectValidator, times(1)).validate(any(), any());
+        verify(conditionsValidator, times(1)).validate(any(), any());
+        verify(levelOfAssuranceValidator, times(1)).validate(any(), any());
+    }
+
+    @Test
+    public void shouldTranslateEidasAssertion() {
+        Assertion eidasAssertion = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        eidasAssertionService.translateSuccessResponse(singletonList(eidasAssertion), "requestId", LevelOfAssurance.LEVEL_2, null);
+
+        verify(eidasMatchingDatasetUnmarshaller, times(1)).fromAssertion(eidasAssertion);
+    }
+
+    @Test(expected = SamlResponseValidationException.class)
+    public void shouldThrowAnExceptionIfMultipleAssertionsReceived() {
+        Assertion eidasAssertion1 = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        Assertion eidasAssertion2 = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        eidasAssertionService.translateSuccessResponse(asList(eidasAssertion1, eidasAssertion2), "requestId", LevelOfAssurance.LEVEL_2, null);
+    }
+
+    @Test
+    public void shouldCorrectlyIdentifyCountryAssertions() {
+        List<String> resolverEntityIds = asList("ID1", "ID2");
+        when(metadataResolverRepository.getResolverEntityIds()).thenReturn(resolverEntityIds);
+
+        Assertion countryAssertion = anAssertion().withIssuer(anIssuer().withIssuerId("ID1").build()).buildUnencrypted();
+        Assertion idpAssertion = anAssertion().withIssuer(anIssuer().withIssuerId("ID3").build()).buildUnencrypted();
+
+        assertThat(eidasAssertionService.isCountryAssertion(countryAssertion)).isTrue();
+        assertThat(eidasAssertionService.isCountryAssertion(idpAssertion)).isFalse();
+    }
+
+
+    private static AssertionBuilder anAssertionWithAuthnStatement(String authnContext, String inResponseTo) {
+        return anAssertion()
+            .addAuthnStatement(
+                anAuthnStatement()
+                    .withAuthnContext(
+                        anAuthnContext()
+                            .withAuthnContextClassRef(
+                                anAuthnContextClassRef()
+                                    .withAuthnContextClasRefValue(authnContext)
+                                    .build())
+                            .build())
+                    .build())
+            .withSubject(anAssertionSubject(inResponseTo))
+            .withIssuer(anIssuer().withIssuerId(STUB_COUNTRY_ONE).build())
+            .addAttributeStatement(anAttributeStatement().addAttribute(anIPAddress().build()).build());
+    }
+
+    private static Subject anAssertionSubject(final String inResponseTo) {
+        return aSubject()
+            .withSubjectConfirmation(
+                aSubjectConfirmation()
+                    .withSubjectConfirmationData(
+                        aSubjectConfirmationData()
+                            .withNotOnOrAfter(DateTime.now())
+                            .withInResponseTo(inResponseTo)
+                            .build()
+                    ).build()
+            ).build();
+    }
+
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/IdpAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/IdpAssertionServiceTest.java
@@ -259,7 +259,7 @@ public class IdpAssertionServiceTest {
         when(userIdHashFactory.hashId(eq(issuerId), eq(nameId), eq(Optional.of(AuthnContext.LEVEL_2))))
                 .thenReturn(expectedHashed);
 
-        TranslatedNonMatchingResponseBody responseBody = nonMatchingAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
+        TranslatedNonMatchingResponseBody responseBody = idpAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
 
         verify(userIdHashFactory, times(1)).hashId(issuerId,nameId, Optional.of(AuthnContext.LEVEL_2));
         assertThat(responseBody.toString()).contains(expectedNonMatchingResponseBody.getPid());

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/IdpAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/IdpAssertionServiceTest.java
@@ -31,7 +31,7 @@ import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationExcepti
 import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier;
-import uk.gov.ida.verifyserviceprovider.services.NonMatchingAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.IdpAssertionService;
 import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 import uk.gov.ida.saml.core.domain.AuthnContext;
@@ -66,9 +66,9 @@ import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_1;
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 
-public class NonMatchingAssertionServiceTest {
+public class IdpAssertionServiceTest {
 
-    private NonMatchingAssertionService nonMatchingAssertionService;
+    private IdpAssertionService idpAssertionService;
 
     @Mock
     private SubjectValidator subjectValidator;
@@ -99,7 +99,7 @@ public class NonMatchingAssertionServiceTest {
         IdaSamlBootstrap.bootstrap();
         initMocks(this);
 
-        nonMatchingAssertionService = new NonMatchingAssertionService(
+        idpAssertionService = new IdpAssertionService(
                 hubSignatureValidator,
                 subjectValidator,
                 attributeStatementValidator,
@@ -126,7 +126,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion IssueInstant is missing.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -136,7 +136,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion Id is missing or blank.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion Id is missing or blank.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -166,7 +166,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -176,7 +176,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion has missing Version.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
 
@@ -197,7 +197,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion with id mds-assertion declared an illegal Version attribute value.");
-        nonMatchingAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        idpAssertionService.validateIdpAssertion(assertion, "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -205,7 +205,7 @@ public class NonMatchingAssertionServiceTest {
         Assertion authnAssertion = anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, "requestId").buildUnencrypted();
         Assertion mdsAssertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
 
-        nonMatchingAssertionService.validate(authnAssertion, mdsAssertion,"requestId", LevelOfAssurance.LEVEL_1, LEVEL_2);
+        idpAssertionService.validate(authnAssertion, mdsAssertion,"requestId", LevelOfAssurance.LEVEL_1, LEVEL_2);
 
         verify(subjectValidator, times(2)).validate(any(), any());
         verify(hubSignatureValidator, times(2)).validate(any(), any());
@@ -216,7 +216,7 @@ public class NonMatchingAssertionServiceTest {
     public void shouldCorrectlyExtractLevelOfAssurance() {
         Assertion authnAssertion = anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, "requestId").buildUnencrypted();
 
-        LevelOfAssurance loa = nonMatchingAssertionService.extractLevelOfAssuranceFrom(authnAssertion);
+        LevelOfAssurance loa = idpAssertionService.extractLevelOfAssuranceFrom(authnAssertion);
 
         assertThat(loa).isEqualTo(LevelOfAssurance.LEVEL_2);
     }
@@ -229,7 +229,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Expected a level of assurance.");
-        nonMatchingAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
+        idpAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
     }
 
 
@@ -240,7 +240,7 @@ public class NonMatchingAssertionServiceTest {
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Level of assurance 'unknown' is not supported.");
-        nonMatchingAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
+        idpAssertionService.translateSuccessResponse(ImmutableList.of(authnAssertion, mdsAssertion), "requestId", LEVEL_2, "default-entity-id");
     }
 
     @Test

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingResponseServiceTest.java
@@ -36,9 +36,7 @@ import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
-import uk.gov.ida.verifyserviceprovider.services.AssertionClassifier;
-import uk.gov.ida.verifyserviceprovider.services.MatchingAssertionService;
-import uk.gov.ida.verifyserviceprovider.services.NonMatchingAssertionService;
+import uk.gov.ida.verifyserviceprovider.services.MsaAssertionService;
 import uk.gov.ida.verifyserviceprovider.services.ResponseService;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
 import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
@@ -121,13 +119,13 @@ public class MatchingResponseServiceTest {
         SubjectValidator subjectValidator = new SubjectValidator(timeRestrictionValidator);
         ConditionsValidator conditionsValidator = new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator());
         AssertionValidator assertionValidator = new AssertionValidator(instantValidator, subjectValidator, conditionsValidator);
-        MatchingAssertionService matchingAssertionService = new MatchingAssertionService(assertionValidator, samlAssertionsSignatureValidator);
+        MsaAssertionService msaAssertionService = new MsaAssertionService(assertionValidator, samlAssertionsSignatureValidator);
 
         ExplicitKeySignatureTrustEngine signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(hubMetadataResolver);
 
         responseService = responseFactory.createMatchingResponseService(
             signatureTrustEngine,
-            matchingAssertionService,
+            msaAssertionService,
             dateTimeComparator
         );
     }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingResponseServiceTest.java
@@ -43,6 +43,7 @@ import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
 import uk.gov.ida.verifyserviceprovider.validators.AudienceRestrictionValidator;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
 import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 import uk.gov.ida.verifyserviceprovider.validators.TimeRestrictionValidator;
 
@@ -119,7 +120,8 @@ public class MatchingResponseServiceTest {
         SubjectValidator subjectValidator = new SubjectValidator(timeRestrictionValidator);
         ConditionsValidator conditionsValidator = new ConditionsValidator(timeRestrictionValidator, new AudienceRestrictionValidator());
         AssertionValidator assertionValidator = new AssertionValidator(instantValidator, subjectValidator, conditionsValidator);
-        MsaAssertionService msaAssertionService = new MsaAssertionService(assertionValidator, samlAssertionsSignatureValidator);
+        LevelOfAssuranceValidator levelOfAssuranceValidator = new LevelOfAssuranceValidator();
+        MsaAssertionService msaAssertionService = new MsaAssertionService(assertionValidator, levelOfAssuranceValidator, samlAssertionsSignatureValidator);
 
         ExplicitKeySignatureTrustEngine signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(hubMetadataResolver);
 

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MsaAssertionServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MsaAssertionServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.ida.verifyserviceprovider.dto.Scenario;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.SamlResponseValidationException;
 import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
 import uk.gov.ida.verifyserviceprovider.services.MsaAssertionService;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
 
@@ -87,7 +88,7 @@ public class MsaAssertionServiceTest {
 
         DateTimeComparator dateTimeComparator = new DateTimeComparator(Duration.standardSeconds(5));
 
-        msaAssertionService = responseFactory.createMsaAssertionService(explicitKeySignatureTrustEngine, dateTimeComparator);
+        msaAssertionService = responseFactory.createMsaAssertionService(explicitKeySignatureTrustEngine, new SignatureValidatorFactory(), dateTimeComparator);
     }
 
     @Rule

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -54,3 +54,14 @@ samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
 # Secondary private key used to decrypt Assertions in the Response
 # This only needs to be set if during key rotations (for example if your primary encryption certificate is about to expire)
 samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
+
+europeanIdentity:
+  enabled: ${EUROPEAN_IDENTITY_ENABLED}
+  hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
+  aggregatedMetadata:
+    trustAnchorUri: ${TRUST_ANCHOR_URI}
+    metadataSourceUri: ${METADATA_SOURCE_URI}
+    trustStore:
+      path: ${TRUSTSTORE_PATH}/ida_metadata_truststore.ts
+      password: ${TRUSTSTORE_PASSWORD}
+    jerseyClientName: trust-anchor-client


### PR DESCRIPTION
https://trello.com/c/JhIrB3HL/266-eidas-functionality-for-the-vsp

This work was originally done on the https://github.com/alphagov/verify-service-provider/tree/JhIrB3HL_eidas-non-matching-journey branch, and is broken down a bit more there (although not very coherently, at least in the case of the commits I authored).

The work includes adding configuration necessary for validating and interpreting eIDAS assertions (in particular, so the necessary metadata and trust anchor can be found).  A new ClassifyingAssertionService class deals with working out whether a Response is from an IDP or eIDAS; it then delegates to an assertion service class tailored for one or the other.

Some of the new classes in this work have not been named well; I'm going to resolve that in a subsequent task.  Also, quite a bit of code was ported across from the MSA; we intend to extract any common code into a shared library later.