### PR TITLE
X27i6hMa: Changed translate-non-matching-response segment of Translat…

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -82,7 +82,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-            .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
             .request()
             .buildPost(json(translateResponseRequestData))
             .invoke();
@@ -127,7 +127,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-            .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
             .request()
             .buildPost(json(translateResponseRequestData))
             .invoke();
@@ -182,7 +182,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-            .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
             .request()
             .buildPost(json(translateResponseRequestData))
             .invoke();
@@ -221,7 +221,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -248,7 +248,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", applicationWithEidasEnabled.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", applicationWithEidasEnabled.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -276,7 +276,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", applicationWithEidasDisabled.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", applicationWithEidasDisabled.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -304,7 +304,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -328,7 +328,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -352,7 +352,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
@@ -377,7 +377,7 @@ public class NonMatchingAcceptanceTest {
         );
 
         Response response = client
-                .target(String.format("http://localhost:%d/translate-non-matching-response", application.getLocalPort()))
+                .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
                 .request()
                 .buildPost(json(translateResponseRequestData))
                 .invoke();

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
@@ -33,7 +33,7 @@ public class NonMatchingEidasAcceptanceTest {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
                  anInvalidAssertionSignatureEidasResponse("requestId", appWithEidasEnabled.getCountryEntityId()).build()
          );
-         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-non-matching-response", appWithEidasEnabled.getLocalPort())).request().post(
+         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
                  Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
          );
 
@@ -48,7 +48,7 @@ public class NonMatchingEidasAcceptanceTest {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
                  aValidEidasResponse("requestId", STUB_COUNTRY_ONE).build()
          );
-         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-non-matching-response", appWithEidasEnabled.getLocalPort())).request().post(
+         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
                  Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
          );
 
@@ -60,7 +60,7 @@ public class NonMatchingEidasAcceptanceTest {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
              aValidEidasResponse("requestId", appWithEidasEnabled.getCountryEntityId()).build()
          );
-         Response response = appWithoutEidasConfig.client().target(format("http://localhost:%s/translate-non-matching-response", appWithoutEidasConfig.getLocalPort())).request().post(
+         Response response = appWithoutEidasConfig.client().target(format("http://localhost:%s/translate-response", appWithoutEidasConfig.getLocalPort())).request().post(
              Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
          );
 
@@ -72,7 +72,7 @@ public class NonMatchingEidasAcceptanceTest {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
              aValidEidasResponse("requestId", appWithEidasDisabled.getCountryEntityId()).build()
          );
-         Response response = appWithEidasDisabled.client().target(format("http://localhost:%s/translate-non-matching-response", appWithEidasDisabled.getLocalPort())).request().post(
+         Response response = appWithEidasDisabled.client().target(format("http://localhost:%s/translate-response", appWithEidasDisabled.getLocalPort())).request().post(
              Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
          );
 
@@ -84,7 +84,7 @@ public class NonMatchingEidasAcceptanceTest {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
              aValidEidasResponse("requestId", appWithEidasEnabled.getCountryEntityId()).build()
          );
-         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-non-matching-response", appWithEidasEnabled.getLocalPort())).request().post(
+         Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
              Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
          );
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateNonMatchingSamlResponseResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/resources/TranslateNonMatchingSamlResponseResource.java
@@ -19,7 +19,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
-@Path("/translate-non-matching-response")
+@Path("/translate-response")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class TranslateNonMatchingSamlResponseResource {

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/TranslateNonMatchingSamlResponseResourceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/TranslateNonMatchingSamlResponseResourceTest.java
@@ -61,7 +61,7 @@ public class TranslateNonMatchingSamlResponseResourceTest {
     public void shouldHaveAPostEndpoint() throws Exception {
 
         Response response = resources.client()
-                .target("/translate-non-matching-response")
+                .target("/translate-response")
                 .request()
                 .post(json(""));
 
@@ -78,7 +78,7 @@ public class TranslateNonMatchingSamlResponseResourceTest {
             .thenReturn(new TranslatedNonMatchingResponseBody(NonMatchingScenario.IDENTITY_VERIFIED, "some-request-id", LEVEL_2, null));
 
         Response response = resources.client()
-            .target("/translate-non-matching-response")
+            .target("/translate-response")
             .request()
             .post(json(translateResponseRequest.toString()));
 


### PR DESCRIPTION
…eNonMatchingSamlResponseResource to translate-response

This is a rename of non matching response url endpoint to /translate-response see
https://trello.com/c/X27i6hMa/12-update-api-endpoints-for-matching-and-non-matching-modes for details
When all references to /translate-non-matching-response are changed to /translate-response all tests
should still pass