### PR TITLE
BgwZOwlj: Add tests for hashingEntityId

### DIFF
--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HashingEntityIdTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/HashingEntityIdTest.java
@@ -1,0 +1,96 @@
+package feature.uk.gov.ida.verifyserviceprovider.configuration;
+
+import common.uk.gov.ida.verifyserviceprovider.utils.EnvironmentHelper;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import keystore.KeyStoreResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
+import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
+import uk.gov.ida.verifyserviceprovider.exceptions.NoHashingEntityIdIsProvidedError;
+
+import java.util.HashMap;
+
+import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
+
+public class HashingEntityIdTest {
+
+    private DropwizardAppRule<VerifyServiceProviderConfiguration> application;
+    private EnvironmentHelper environmentHelper = new EnvironmentHelper();
+
+    @Before
+    public void setUp() {
+        KeyStoreResource keyStoreResource = aKeyStoreResource()
+            .withCertificate("any-alias", aCertificate().build().getCertificate())
+            .build();
+        keyStoreResource.create();
+        application = new DropwizardAppRule<>(
+            VerifyServiceProviderApplication.class,
+            "verify-service-provider-no-hashing-entity-id.yml",
+            ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
+            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", keyStoreResource.getAbsolutePath()),
+            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", keyStoreResource.getPassword()),
+            ConfigOverride.config("europeanIdentity.enabled", "false"),
+            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", keyStoreResource.getAbsolutePath()),
+            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", keyStoreResource.getPassword())
+        );
+    }
+
+    @After
+    public void cleanup() {
+        application.getTestSupport().after();
+        environmentHelper.cleanEnv();
+    }
+
+    @Test
+    public void applicationShouldStartUpWithSingleServiceEntityIdIfNoHashingEntityIdProvided() throws Exception {
+        environmentHelper.setEnv(new HashMap<String, String>() {{
+            put("PORT", "50555");
+            put("LOG_LEVEL", "ERROR");
+            put("VERIFY_ENVIRONMENT", "COMPLIANCE_TOOL");
+            put("SERVICE_ENTITY_IDS", "[\"http://some-service-entity-id\"]");
+            put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
+            put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
+            put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
+            put("CLOCK_SKEW", "PT30s");
+        }});
+
+        application.getTestSupport().before();
+
+        VerifyServiceProviderConfiguration configuration = application.getConfiguration();
+
+        assertThat(configuration.getHashingEntityId()).isEqualTo("http://some-service-entity-id");
+    }
+
+    @Test(expected = NoHashingEntityIdIsProvidedError.class)
+    public void applicationShouldFailToStartWithMultipleServiceEntityIdsIfNoHashingEntityIdProvided() throws Exception {
+        environmentHelper.setEnv(new HashMap<String, String>() {{
+            put("PORT", "50555");
+            put("LOG_LEVEL", "ERROR");
+            put("VERIFY_ENVIRONMENT", "COMPLIANCE_TOOL");
+            put("SERVICE_ENTITY_IDS", "[\"http://some-service-entity-id\",\"http://some-other-service-entity-id\"]");
+            put("HASHING_ENTITY_ID", "some-hashing-entity-id");
+            put("SAML_SIGNING_KEY", TEST_RP_PRIVATE_SIGNING_KEY);
+            put("SAML_PRIMARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
+            put("SAML_SECONDARY_ENCRYPTION_KEY", TEST_RP_PRIVATE_ENCRYPTION_KEY);
+            put("CLOCK_SKEW", "PT30s");
+        }});
+
+
+        application.getTestSupport().before();
+
+        VerifyServiceProviderConfiguration configuration = application.getConfiguration();
+
+        assertThat(configuration.getHashingEntityId()).isEqualTo("some-hashing-entity-id");
+    }
+
+}

--- a/verify-service-provider-no-hashing-entity-id.yml
+++ b/verify-service-provider-no-hashing-entity-id.yml
@@ -1,0 +1,55 @@
+# This is an example configuration file to show how to configure
+# the application using a YAML file.
+
+# Dropwizard server connector configuration
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#servers
+server:
+  type: simple
+  applicationContextPath: /
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: ${PORT:-50400}
+
+# Logging configuration
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#logging
+logging:
+  level: ${LOG_LEVEL:-INFO}
+  appenders:
+    - type: console
+    - type: file
+      currentLogFilename: logs/verify-service-provider.log
+      archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
+
+clockSkew: ${CLOCK_SKEW:-PT30s}
+
+# Entity ID (or IDs) that uniquely identifies your service (or services)
+serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
+
+# Verify Hub Environment. This tells the service provider where the Verify Hub
+# authentication flow begins and where to find the hub metadata the Verify Service
+# Provider consumes to identify the hub.
+# Valid values: COMPLIANCE_TOOL, INTEGRATION, PRODUCTION
+verifyHubConfiguration:
+  environment: ${VERIFY_ENVIRONMENT:-}
+
+# Private key that is used to sign an AuthnRequest
+samlSigningKey: ${SAML_SIGNING_KEY:-}
+
+# Private key used to decrypt Assertions in the Response
+samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
+
+# Secondary private key used to decrypt Assertions in the Response
+# This only needs to be set if during key rotations (for example if your primary encryption certificate is about to expire)
+samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
+
+europeanIdentity:
+  enabled: ${EUROPEAN_IDENTITY_ENABLED:-false}
+  hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
+  aggregatedMetadata:
+    trustAnchorUri: ${TRUST_ANCHOR_URI:-"http://example"}
+    metadataSourceUri: ${METADATA_SOURCE_URI:-"http://example"}
+    trustStore:
+      path: ${TRUSTSTORE_PATH}/ida_metadata_truststore.ts
+      password: ${TRUSTSTORE_PASSWORD}
+    jerseyClientName: trust-anchor-client


### PR DESCRIPTION
https://trello.com/c/BgwZOwlj/41-make-hashingentityid-optional

The logic around whether hashingEntityId is allowed to be absent in the config is just about complex enough that we should have some tests for it.  Some of the existing tests kind of happen to cover that things work correctly when it is present; I have added some tests which check that we get the correct behaviour when it's not present.

I'm not great with DropWizard AppRules, and I can't see a clean way to get the tests into the same class file, so I've ended up with a bit of a weird test class which only tests the absence cases, rather than having all of the relevant test coverage in one place - suggestions for how to clean this up are welcome.  Likewise, the only way I know of to get rid of a config item in an AppRule is to base the AppRule on a config file which doesn't have the config item - setting it to null in a ConfigOverride doesn't seem to work.  Again, if you know a cleaner way to do this, I am all ears!