### PR TITLE
7DyD3EvQ: remove unused file option from Development mode

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolMode.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolMode.java
@@ -43,8 +43,6 @@ public class ComplianceToolMode extends ServerCommand<VerifyServiceProviderConfi
 
     @Override
     public void configure(Subparser subparser) {
-        super.configure(subparser);
-
         subparser.addArgument("-d", "--matchingDataset")
                 .dest(MATCHING_DATASET)
                 .type(matchingDatasetArgumentResolver)


### PR DESCRIPTION
The file option is never used in development mode so I've removed it as an option to development mode.