### PR TITLE
2uk41vWL: return NO_AUTHENTICATION for NOAUTHNCONTEXT

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -382,6 +382,6 @@ public class NonMatchingAcceptanceTest {
         TestTranslatedNonMatchingResponseBody responseContent = response.readEntity(TestTranslatedNonMatchingResponseBody.class);
 
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
-        assertThat(responseContent.getScenario()).isEqualTo(NonMatchingScenario.CANCELLATION);
+        assertThat(responseContent.getScenario()).isEqualTo(NonMatchingScenario.NO_AUTHENTICATION);
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingScenario.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingScenario.java
@@ -2,7 +2,7 @@ package uk.gov.ida.verifyserviceprovider.dto;
 
 public enum NonMatchingScenario implements Scenario {
     IDENTITY_VERIFIED,
-    CANCELLATION,
+    NO_AUTHENTICATION,
     AUTHENTICATION_FAILED,
     REQUEST_ERROR
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionServiceV2.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/AssertionServiceV2.java
@@ -46,7 +46,7 @@ public abstract class AssertionServiceV2 implements AssertionService<TranslatedN
             case StatusCode.REQUESTER:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.REQUEST_ERROR, null, null, null);
             case StatusCode.NO_AUTHN_CONTEXT:
-                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.CANCELLATION, null, null, null);
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.NO_AUTHENTICATION, null, null, null);
             case StatusCode.AUTHN_FAILED:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.AUTHENTICATION_FAILED, null, null, null);
             default:

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionService.java
@@ -42,7 +42,7 @@ public class ClassifyingAssertionService implements AssertionService<TranslatedN
             case StatusCode.REQUESTER:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.REQUEST_ERROR, null, null, null);
             case StatusCode.NO_AUTHN_CONTEXT:
-                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.CANCELLATION, null, null, null);
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.NO_AUTHENTICATION, null, null, null);
             case StatusCode.AUTHN_FAILED:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.AUTHENTICATION_FAILED, null, null, null);
             default:

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/IdpAssertionService.java
@@ -89,7 +89,7 @@ public class IdpAssertionService extends AssertionServiceV2 {
             case StatusCode.REQUESTER:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.REQUEST_ERROR, null, null, null);
             case StatusCode.NO_AUTHN_CONTEXT:
-                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.CANCELLATION, null, null, null);
+                return new TranslatedNonMatchingResponseBody(NonMatchingScenario.NO_AUTHENTICATION, null, null, null);
             case StatusCode.AUTHN_FAILED:
                 return new TranslatedNonMatchingResponseBody(NonMatchingScenario.AUTHENTICATION_FAILED, null, null, null);
             default:


### PR DESCRIPTION
- The VSP has always returned CANCELLATION in response to NOAUTHNCONTEXT, but this was a mistake.
- For a non-matching journey, we will now return NO_AUTHENTICATION in that scenario.
_ For backwards compatibility, the matching journey will continue to return CANCELLATION.

https://trello.com/c/2uk41vWL/71-vsp-should-return-noauthentication-instead-of-cancellation-as-a-possible-scenario-in-its-responses