### PR TITLE
Improve description of default matching dataset

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolMode.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolMode.java
@@ -18,7 +18,7 @@ import java.net.URL;
 
 public class ComplianceToolMode extends ServerCommand<VerifyServiceProviderConfiguration> {
 
-    static final String MATCHING_DATASET = "matchingDataset";
+    static final String IDENTITY_DATASET = "identityDataset";
     static final String ASSERTION_CONSUMER_URL = "assertionConsumerUrl";
     static final String TIMEOUT = "timeout";
     static final String PORT = "port";
@@ -27,24 +27,24 @@ public class ComplianceToolMode extends ServerCommand<VerifyServiceProviderConfi
     static final int DEFAULT_PORT = 50300;
     static final String DEFAULT_CONSUMER_URL = "http://localhost:8080/SAML2/Response";
     static final String DEFAULT_HOST = "0.0.0.0";
-    private final MatchingDataset defaultMatchingDataset;
+    private final MatchingDataset defaultIdentityDataset;
 
-    private MatchingDatasetArgumentResolver matchingDatasetArgumentResolver;
+    private IdentityDatasetArgumentResolver identityDatasetArgumentResolver;
 
     public ComplianceToolMode(ObjectMapper objectMapper, Validator validator, Application<VerifyServiceProviderConfiguration> application) {
         super(application, "development", "Run the VSP in development mode");
-        this.matchingDatasetArgumentResolver = new MatchingDatasetArgumentResolver(objectMapper, validator);
-        this.defaultMatchingDataset = createDefaultMatchingDataset(objectMapper);
+        this.identityDatasetArgumentResolver = new IdentityDatasetArgumentResolver(objectMapper, validator);
+        this.defaultIdentityDataset = createDefaultIdentityDataset(objectMapper);
     }
 
 
     @Override
     public void configure(Subparser subparser) {
-        subparser.addArgument("-d", "--matchingDataset")
-                .dest(MATCHING_DATASET)
-                .type(matchingDatasetArgumentResolver)
-                .setDefault(defaultMatchingDataset)
-                .help("The Matching Dataset that the Compliance Tool will be initialized with");
+        subparser.addArgument("-d", "--identityDataset")
+                .dest(IDENTITY_DATASET)
+                .type(identityDatasetArgumentResolver)
+                .setDefault(defaultIdentityDataset)
+                .help("The identity dataset that the Compliance Tool will be initialized with");
 
         subparser.addArgument("-u", "--url")
                 .dest(ASSERTION_CONSUMER_URL)
@@ -90,7 +90,7 @@ public class ComplianceToolMode extends ServerCommand<VerifyServiceProviderConfi
     protected void run(Environment environment, Namespace namespace, VerifyServiceProviderConfiguration configuration) throws Exception {
         String url = namespace.get(ASSERTION_CONSUMER_URL);
         Integer timeout = namespace.get(TIMEOUT);
-        MatchingDataset matchingDataset = namespace.get(MATCHING_DATASET);
+        MatchingDataset matchingDataset = namespace.get(IDENTITY_DATASET);
 
         ComplianceToolModeConfiguration complianceToolModeConfiguration = (ComplianceToolModeConfiguration) configuration;
 
@@ -106,17 +106,17 @@ public class ComplianceToolMode extends ServerCommand<VerifyServiceProviderConfi
                 new ComplianceToolModeConfigurationFactory(port, bindHost);
     }
 
-    private static MatchingDataset createDefaultMatchingDataset(ObjectMapper objectMapper) {
+    private static MatchingDataset createDefaultIdentityDataset(ObjectMapper objectMapper) {
         URL resource = Resources.getResource("default-test-identity-dataset.json");
         try {
-            return objectMapper.readValue(resource, DefaultMatchingDataset.class);
+            return objectMapper.readValue(resource, DefaultIdentityDataset.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static class DefaultMatchingDataset extends MatchingDataset {
-        public DefaultMatchingDataset() {
+    public static class DefaultIdentityDataset extends MatchingDataset {
+        public DefaultIdentityDataset() {
         }
 
         @Override

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/IdentityDatasetArgumentResolver.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/IdentityDatasetArgumentResolver.java
@@ -15,12 +15,12 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-class MatchingDatasetArgumentResolver implements ArgumentType<MatchingDataset> {
+class IdentityDatasetArgumentResolver implements ArgumentType<MatchingDataset> {
 
     private final ObjectMapper objectMapper;
     private final Validator validator;
 
-    public MatchingDatasetArgumentResolver(ObjectMapper objectMapper, Validator validator) {
+    public IdentityDatasetArgumentResolver(ObjectMapper objectMapper, Validator validator) {
         this.objectMapper = objectMapper;
         this.validator = validator;
     }

--- a/src/main/resources/default-test-identity-dataset.json
+++ b/src/main/resources/default-test-identity-dataset.json
@@ -1,0 +1,55 @@
+{
+  "firstName": {
+    "value": "Default",
+    "from": "2013-02-22T14:32:14.064",
+    "to": "2015-10-02T09:32:14.967",
+    "verified": true
+  },
+  "middleNames": {
+    "value": "Person",
+    "from": "2013-02-22T14:32:14.064",
+    "to": "2015-10-02T09:32:14.967",
+    "verified": true
+  },
+  "surnames": [
+    {
+      "value": "Smith",
+      "from": "2013-02-22T14:32:14.064",
+      "to": "2015-10-02T09:32:14.967",
+      "verified": true
+    },
+    {
+      "value": "Smythington",
+      "from": "2015-10-02T09:32:14.967",
+      "to": "2018-03-03T10:20:50.163",
+      "verified": true
+    }
+  ],
+  "gender": {
+    "value": "NOT_SPECIFIED",
+    "from": "2013-02-22T14:32:14.064",
+    "to": "2015-10-02T09:32:14.967",
+    "verified": true
+  },
+  "dateOfBirth": {
+    "value": "1970-01-01",
+    "from": "2013-02-22T14:32:14.064",
+    "to": "2015-10-02T09:32:14.967",
+    "verified": true
+  },
+  "addresses": [
+    {
+      "verified": true,
+      "from": "2013-02-22T14:32:14.064",
+      "to": "2015-10-02T09:32:14.967",
+      "postCode": "E1 8QS",
+      "lines": [
+        "The White Chapel Building",
+        "10 Whitechapel High Street"
+      ],
+      "internationalPostCode": null,
+      "uprn": null
+    }
+  ],
+  "persistentId": "ff5de5e2-6070-44e7-985b-2079637b878e"
+}

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeTest.java
@@ -50,7 +50,7 @@ public class ComplianceToolModeTest {
                 )
         );
 
-        MatchingDataset actual = namespace.get(ComplianceToolMode.MATCHING_DATASET);
+        MatchingDataset actual = namespace.get(ComplianceToolMode.IDENTITY_DATASET);
         assertThat(actual).isEqualToComparingFieldByFieldRecursively(suppliedMatchingDataset);
 
         String url = namespace.get(ComplianceToolMode.ASSERTION_CONSUMER_URL);
@@ -76,7 +76,7 @@ public class ComplianceToolModeTest {
 
         Namespace namespace = subparser.parseArgs(noArguments());
 
-        MatchingDataset actual = namespace.get(ComplianceToolMode.MATCHING_DATASET);
+        MatchingDataset actual = namespace.get(ComplianceToolMode.IDENTITY_DATASET);
         String expectedMatchingDataset = FixtureHelpers.fixture("default-test-identity-dataset.json");
         String receivedMatchingDataset = objectMapper.writeValueAsString(actual);
         assertThat(new JSONObject(receivedMatchingDataset))


### PR DESCRIPTION
What
=====

use a file to store the devmode default identity dataset so it can be easily referenced in READMEs and other guides.

Also, provide a reference tn the docs to find out more about the default identity dataset as it's too large to include in the CLI.

Finally, rename the CLI option of --matchingDataset to --identityDataset

We have chosen identityDataset as it better reflects the domain (i.e. where matching is independent of the VSP and Hub).