### PR TITLE
fix: support for eidas identities in development mode

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -48,6 +48,8 @@ import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
+import static uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker.checkMdsValueInArrayAttributeWithoutDates;
+import static uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker.checkMdsValueOfAttributeWithoutDates;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.VERIFIED_USER_ON_SERVICE_WITH_NON_MATCH_SETTING_ID;
 
 public class ComplianceToolModeAcceptanceTest {
@@ -223,6 +225,59 @@ public class ComplianceToolModeAcceptanceTest {
         assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "gender", "addresses");
 
         checkMatchingDatasetMatches(attributes, newMatchingDataset);
+
+    }
+
+    @Test
+    public void shouldLetYouUseEidasStyleAttributes() throws Exception {
+        MatchingDataset matchingDataset = new MatchingDatasetBuilder().withEidasFirstName("FOO")
+                .withEidasMiddlename("BAR")
+                .withEidasSurname("BAZ")
+                .withoutAddress()
+                .withoutGender()
+                .withDateOfBirth("1970-01-01")
+                .build();
+
+        Response refreshDataset = client
+                .target(appUri("refresh-matching-dataset"))
+                .request()
+                .post(json(matchingDataset));
+
+        assertThat(refreshDataset.getStatus()).isEqualTo(200);
+
+        Response authnRequest = client
+                .target(appUri("generate-request"))
+                .request()
+                .post(json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)));
+
+        assertThat(authnRequest.getStatus()).isEqualTo(200);
+        RequestResponseBody authnSaml = authnRequest.readEntity(RequestResponseBody.class);
+
+        assertThat(authnSaml.getSsoLocation()).isEqualTo(URI.create(COMPLIANCE_TOOL_HOST + "/SAML2/SSO"));
+        String responseFor = complianceTool.createResponseFor(authnSaml.getSamlRequest(), VERIFIED_USER_ON_SERVICE_WITH_NON_MATCH_SETTING_ID);
+
+        Map<String, String> translateResponseRequestData = ImmutableMap.of(
+                "samlResponse", responseFor,
+                "requestId", authnSaml.getRequestId(),
+                "levelOfAssurance", LevelOfAssurance.LEVEL_1.name());
+
+        Response response = client
+                .target(appUri("translate-response"))
+                .request()
+                .post(json(translateResponseRequestData));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
+
+        JSONObject attributes = jsonResponse.getJSONObject("attributes");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "addresses");
+
+        checkMdsValueOfAttributeWithoutDates("firstName", matchingDataset.getFirstName().getValue(), matchingDataset.getFirstName().isVerified(), attributes);
+        checkMdsValueOfAttributeWithoutDates("dateOfBirth", matchingDataset.getDateOfBirth().getValue(), matchingDataset.getDateOfBirth().isVerified(), attributes);
+        checkMdsValueInArrayAttributeWithoutDates("surnames", 0, matchingDataset.getSurnames().get(0).getValue(), matchingDataset.getSurnames().get(0).isVerified(), attributes);
+        checkMdsValueInArrayAttributeWithoutDates("middleNames", 0, matchingDataset.getMiddleNames().getValue(), matchingDataset.getMiddleNames().isVerified(), attributes);
+        assertThat(attributes.getJSONArray("addresses")).isEmpty();
 
     }
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
@@ -20,6 +20,16 @@ public class MdsValueChecker {
         checkMdsValueInJsonObject(attribute, expectedValue, expectedIsVerified, expectedFromDateString, expectedToDateString);
     }
 
+    public static void checkMdsValueOfAttributeWithoutDates(
+            String attributeName,
+            String expectedValue,
+            boolean expectedIsVerified,
+            JSONObject attributes
+    ) {
+        JSONObject attribute = attributes.getJSONObject(attributeName);
+        checkMdsValueInJsonObject(attribute, expectedValue, expectedIsVerified);
+    }
+
     public static void checkMdsValueOfAddress(
             int index,
             List<String> lines,
@@ -35,7 +45,7 @@ public class MdsValueChecker {
         JSONObject addressValue = addressMdsValue.getJSONObject("value");
 
         // TODO: The Compliance Tool isn't currently returning from/to dates for addresses.  Until that is fixed, the next line needs to be commented out.
-        //checkMdsMetadataInJsonObject(addressMdsValue, expectedIsVerified, expectedFromDateString, expectedToDateString);
+//        checkMdsMetadataInJsonObject(addressMdsValue, expectedIsVerified, expectedFromDateString, expectedToDateString);
 
         JSONArray jsonLines = addressValue.getJSONArray("lines");
         Assertions.assertThat(jsonLines.length()).isEqualTo(lines.size());
@@ -60,6 +70,18 @@ public class MdsValueChecker {
         checkMdsValueInJsonObject(mdsObjectJson, expectedValue, expectedIsVerified, expectedFromDateString, expectedToDateString);
     }
 
+    public static void checkMdsValueInArrayAttributeWithoutDates(
+            String attributeName,
+            int index,
+            String expectedValue,
+            boolean expectedIsVerified,
+            JSONObject attributes
+    ) {
+        JSONArray jsonArray = attributes.getJSONArray(attributeName);
+        JSONObject mdsObjectJson = jsonArray.getJSONObject(index);
+        checkMdsValueInJsonObject(mdsObjectJson, expectedValue, expectedIsVerified);
+    }
+
     public static void checkMdsValueInJsonObject(
             JSONObject jsonObject,
             String expectedValue,
@@ -82,5 +104,23 @@ public class MdsValueChecker {
         if (expectedToDateString != null) {
             Assertions.assertThat(jsonObject.getString("to")).isEqualTo(expectedToDateString);
         }
+    }
+
+    public static void checkMdsValueInJsonObject(
+            JSONObject jsonObject,
+            String expectedValue,
+            boolean expectedIsVerified
+    ) {
+        Assertions.assertThat(jsonObject.getString("value")).isEqualTo(expectedValue);
+        checkMdsMetadataInJsonObject(jsonObject, expectedIsVerified);
+    }
+
+    public static void checkMdsMetadataInJsonObject(
+            JSONObject jsonObject,
+            boolean expectedIsVerified
+    ) {
+        Assertions.assertThat(jsonObject.getBoolean("verified")).isEqualTo(expectedIsVerified);
+        Assertions.assertThat(jsonObject.has("from")).isFalse();
+        Assertions.assertThat(jsonObject.has("to")).isFalse();
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingAttribute.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingAttribute.java
@@ -37,6 +37,11 @@ public class MatchingAttribute {
         return verified;
     }
 
+    public MatchingAttribute(String value) {
+        this.value = value;
+        this.verified = true;
+    }
+
     public MatchingAttribute(
             final String value,
             final boolean verified,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDataset.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDataset.java
@@ -1,6 +1,9 @@
 package uk.gov.ida.verifyserviceprovider.compliance.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -20,9 +23,11 @@ public class MatchingDataset {
     @NotNull
     @Valid
     @JsonProperty
+    @NotEmpty
     private List<MatchingAttribute> surnames;
 
-    @NotNull
+
+    @JsonInclude(Include.NON_NULL)
     @Valid
     @JsonProperty
     private MatchingAttribute gender;
@@ -32,9 +37,9 @@ public class MatchingDataset {
     @JsonProperty
     private MatchingAttribute dateOfBirth;
 
-    @NotNull
     @Valid
     @JsonProperty
+    @JsonInclude(Include.NON_NULL)
     private List<MatchingAddress> addresses;
 
     @NotNull

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDatasetBuilder.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDatasetBuilder.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.verifyserviceprovider.compliance.dto;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,6 +35,10 @@ public class MatchingDatasetBuilder {
 
     public MatchingDatasetBuilder withFirstName(String value, boolean verified, LocalDateTime fromDate, LocalDateTime toDate) {
         return withFirstName(new MatchingAttribute(value, verified, fromDate, toDate));
+    }
+
+    public MatchingDatasetBuilder withEidasFirstName(String value) {
+        return withFirstName(new MatchingAttribute(value));
     }
 
     public MatchingDatasetBuilder withMiddleNames(MatchingAttribute middleNames) {
@@ -78,6 +83,10 @@ public class MatchingDatasetBuilder {
         return this;
     }
 
+    public MatchingDatasetBuilder withDateOfBirth(String dateOfBirth) {
+        return withDateOfBirth(new MatchingAttribute(dateOfBirth));
+    }
+
     public MatchingDatasetBuilder withDateOfBirth(String value, boolean verified, LocalDateTime fromDate, LocalDateTime toDate) {
         return withDateOfBirth(new MatchingAttribute(value, verified, fromDate, toDate));
     }
@@ -99,5 +108,24 @@ public class MatchingDatasetBuilder {
 
     public MatchingDataset build() {
         return new MatchingDataset(firstName, middleNames, surnames, gender, dateOfBirth, addresses, persistentId);
+    }
+
+    public MatchingDatasetBuilder withEidasSurname(String value) {
+        this.surnames = Collections.singletonList(new MatchingAttribute(value));
+        return this;
+    }
+
+    public MatchingDatasetBuilder withEidasMiddlename(String value) {
+        return withMiddleNames(new MatchingAttribute(value));
+    }
+
+    public MatchingDatasetBuilder withoutAddress() {
+        this.addresses = null;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutGender() {
+        this.gender = null;
+        return this;
     }
 }


### PR DESCRIPTION
When the VSP runs in development mode we need to be able to have some
support for eIDAS identities. An eIDAS identity will have attributes that
are missing `from` and `to` dates. Some attributes may also be absent.

This change includes tests and changes to how the Dto that is sent
to CT, and contains the identity, serializes itself.