### PR TITLE
qQOLcfG7: Add missing dependency on Java11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ dependencies {
         "uk.gov.ida:saml-extensions:$samlLibVersion",
         "uk.gov.ida:hub-saml:$hub_saml",
         "org.bouncycastle:bcprov-jdk15on:1.60",
-        "org.bouncycastle:bcpkix-jdk15on:1.60"
+        "org.bouncycastle:bcpkix-jdk15on:1.60",
+        "javax.activation:javax.activation-api:1.2.0"
     )
     compile("commons-collections:commons-collections:3.2.2") { force = true }
     testCompile(


### PR DESCRIPTION
When running on Java 11 the following dependency is needed:
```
javax.activation:javax.activation-api:1.2.0
```

Otherwise when you start the VSP there are lots of warning messages
related to:
```
java.lang.NoClassDefFoundError: javax/activation/DataSource
```