### PR TITLE
BAU: Remove failing task from Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gradle
+build
+logs

--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -5,12 +5,6 @@ ENV GRADLE_USER_HOME ~/.gradle
 
 COPY build.gradle build.gradle
 COPY settings.gradle settings.gradle
-# There is an issue running idea.gradle in the container
-# So just make this an empty file
-RUN touch idea.gradle
-RUN gradle install
-
-
 COPY src src
 
 RUN gradle installDist


### PR DESCRIPTION
- Gradle install fails the docker build and was meant to greedily cache
  the dependencies but doesn't do that
- This repository is fairly small so the build is quick anyway
- Also add a .dockerignore to make builds faster as we don't have to
  push the whole context to the docker daemon