### PR TITLE
f7X3GoiN: configure the vsps eidas functionality using its hub environment config property

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
@@ -126,7 +126,7 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
             verifyMetadataServer.register(VERIFY_METADATA_PATH, 200, Constants.APPLICATION_SAMLMETADATA_XML, new MetadataFactory().defaultMetadata());
 
             trustAnchorServer.reset();
-            trustAnchorServer.register(TRUST_ANCHOR_PATH, 200, MediaType.APPLICATION_OCTET_STREAM, buildTrustAnchorString());
+            trustAnchorServer.register(TRUST_ANCHOR_PATH, 200, MediaType.APPLICATION_OCTET_STREAM, buildTrustAnchorString(countryEntityId));
 
             metadataAggregatorServer.reset();
             metadataAggregatorServer.register(METADATA_SOURCE_PATH + "/" + entityIdAsResource(countryEntityId), 200, Constants.APPLICATION_SAMLMETADATA_XML, testCountryMetadata);
@@ -137,7 +137,7 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
         super.before();
     }
 
-    private String buildTrustAnchorString() throws JOSEException, CertificateEncodingException {
+    private String buildTrustAnchorString(String countryEntityId) throws JOSEException, CertificateEncodingException {
         X509CertificateFactory x509CertificateFactory = new X509CertificateFactory();
         PrivateKey trustAnchorKey = new PrivateKeyFactory().createPrivateKey(Base64.getDecoder().decode(METADATA_SIGNING_A_PRIVATE_KEY));
         X509Certificate trustAnchorCert = x509CertificateFactory.createCertificate(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT);

--- a/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfigurationImpl.java
+++ b/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfigurationImpl.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.saml.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.client.JerseyClientConfiguration;
+import uk.gov.ida.verifyserviceprovider.configuration.HubEnvironment;
+
+import java.net.URI;
+import java.security.KeyStore;
+import java.util.Optional;
+
+public class EidasMetadataConfigurationImpl extends EidasMetadataConfiguration {
+
+    private TrustStoreConfiguration trustStoreConfiguration;
+    private HubEnvironment environment;
+
+    public EidasMetadataConfigurationImpl(){
+        this(null, null, null, null, null, null, null, null, null);
+    }
+    @JsonCreator
+    public EidasMetadataConfigurationImpl(@JsonProperty("trustAnchorUri") URI trustAnchorUri,
+                                      @JsonProperty("minRefreshDelay") Long minRefreshDelay,
+                                      @JsonProperty("maxRefreshDelay") Long maxRefreshDelay,
+                                      @JsonProperty("trustAnchorMaxRefreshDelay") Long trustAnchorMaxRefreshDelay,
+                                      @JsonProperty("trustAnchorMinRefreshDelay") Long trustAnchorMinRefreshDelay,
+                                      @JsonProperty("client") JerseyClientConfiguration client,
+                                      @JsonProperty("jerseyClientName") String jerseyClientName,
+                                      @JsonProperty("trustStoreConfiguration") TrustStoreConfiguration trustStore,
+                                      @JsonProperty("metadataSourceUri") URI metadataSourceUri
+    )
+    {
+        super(trustAnchorUri, minRefreshDelay, maxRefreshDelay, trustAnchorMaxRefreshDelay, trustAnchorMinRefreshDelay, client, jerseyClientName, trustStore, metadataSourceUri);
+        this.trustStoreConfiguration = trustStore;
+    }
+
+    @Override
+    public KeyStore getTrustStore() {
+        if (trustStoreConfiguration !=null){
+            return super.getTrustStore();
+        }
+        return environment.getMetadataTrustStore();
+    }
+    @Override
+    public URI getMetadataSourceUri() {
+        return Optional.ofNullable(super.getMetadataSourceUri())
+                .orElse(environment.getEidasMetadataSourceUri());
+    }
+
+    @Override
+    public URI getTrustAnchorUri() {
+        return Optional.ofNullable(super.getTrustAnchorUri())
+                .orElse(environment.getEidasMetadataTrustAnchorUri());
+    }
+
+    public void setEnvironment(HubEnvironment environment) {
+        this.environment = environment;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfigurationImpl.java
+++ b/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfigurationImpl.java
@@ -25,7 +25,7 @@ public class EidasMetadataConfigurationImpl extends EidasMetadataConfiguration {
                                       @JsonProperty("trustAnchorMinRefreshDelay") Long trustAnchorMinRefreshDelay,
                                       @JsonProperty("client") JerseyClientConfiguration client,
                                       @JsonProperty("jerseyClientName") String jerseyClientName,
-                                      @JsonProperty("trustStoreConfiguration") TrustStoreConfiguration trustStore,
+                                      @JsonProperty("trustStore") TrustStoreConfiguration trustStore,
                                       @JsonProperty("metadataSourceUri") URI metadataSourceUri
     )
     {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeConfiguration.java
@@ -30,7 +30,7 @@ public class ComplianceToolModeConfiguration extends VerifyServiceProviderConfig
               encryptionKeysAndCert.getPrivate(),
               Optional.empty(),
               org.joda.time.Duration.standardMinutes(2),
-              null);
+              Optional.empty());
 
         this.serviceEntityId = serviceEntityId;
         this.signingKeysAndCert = signingKeysAndCert;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
@@ -18,4 +18,27 @@ public interface ConfigurationConstants {
 
     String HUB_JERSEY_CLIENT_NAME = "VerifyHubMetadataClient";
     String MSA_JERSEY_CLIENT_NAME = "MsaMetadataClient";
+
+    interface EnvironmentUrls {
+
+        String PRODUCTION_HOST ="https://www.signin.service.gov.uk";
+        String INTEGRATION_HOST ="https://www.integration.signin.service.gov.uk";
+        String COMPLIANCE_HOST = "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk";
+
+
+        String PRODUCTION_SSO = PRODUCTION_HOST + "/SAML2/SSO";
+        String PRODUCTION_METADATA = PRODUCTION_HOST + "/SAML2/metadata/federation";
+        String PRODUCTION_TRUSTANCHOR_URI = PRODUCTION_HOST + "/SAML2/metadata/trust-anchor";
+        String PRODUCTION_METADATASOURCE_URI = PRODUCTION_HOST + "/SAML2/metadata/aggregator";
+
+        String INTEGRATION_SSO = INTEGRATION_HOST + "/SAML2/SSO";
+        String INTEGRATION_METADATA = INTEGRATION_HOST +  "/SAML2/metadata/federation";
+        String INTEGRATION_TRUSTANCHOR_URI = INTEGRATION_HOST + "/SAML2/metadata/trust-anchor";
+        String INTEGRATION_METADATASOURCE_URI = INTEGRATION_HOST + "/SAML2/metadata/aggregator";
+
+        String COMPLIANCE_SSO = COMPLIANCE_HOST + "/SAML2/SSO";
+        String COMPLIANCE_METADATA = COMPLIANCE_HOST +  "/SAML2/metadata/federation";
+        String COMPLIANCE_TRUSTANCHOR_URI = COMPLIANCE_HOST +  "/SAML2/metadata/trust-anchor";
+        String COMPLIANCE_METADATASOURCE_URI = COMPLIANCE_HOST + "/SAML2/metadata/aggregator";
+    }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -1,36 +1,72 @@
 package uk.gov.ida.verifyserviceprovider.configuration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+import uk.gov.ida.saml.metadata.EncodedTrustStoreConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.security.KeyStore;
+
+import static java.util.Optional.ofNullable;
 
 public class EuropeanIdentityConfiguration {
 
-    @NotNull
-    @Valid
-    @JsonProperty
     private String hubConnectorEntityId;
-
-    @NotNull
-    @Valid
-    @JsonProperty
     private boolean enabled;
-
-    @Valid
-    @JsonProperty
     private EidasMetadataConfiguration aggregatedMetadata;
+    private HubEnvironment environment;
+
+    @JsonCreator
+    public EuropeanIdentityConfiguration(
+            @JsonProperty("hubConnectorEntityId") String hubConnectorEntityId,
+            @NotNull @Valid @JsonProperty("enabled") boolean enabled,
+            @Valid @JsonProperty("aggregatedMetadata") EidasMetadataConfiguration aggregatedMetadata
+    ){
+        this.enabled = enabled;
+        this.hubConnectorEntityId = hubConnectorEntityId;
+        this.aggregatedMetadata = ofNullable(aggregatedMetadata).orElse(createEidasMetadataConfigurationWithDefaults());
+    }
 
     public String getHubConnectorEntityId() {
         return hubConnectorEntityId;
+    }
+
+    @JsonIgnore
+    public void setEnvironment(HubEnvironment environment) {
+        this.environment = environment;
     }
 
     public EidasMetadataConfiguration getAggregatedMetadata() {
         return aggregatedMetadata;
     }
 
+    public URI getMetadataSourceUri() {
+        return ofNullable(aggregatedMetadata)
+                .map(EidasMetadataConfiguration::getMetadataSourceUri)
+                .orElseGet(environment::getEidasMetadataSourceUri);
+    }
+
+    public KeyStore getTrustStore() {
+        return ofNullable(aggregatedMetadata)
+                .map(EidasMetadataConfiguration::getTrustStore)
+                .orElseGet(environment::getMetadataTrustStore);
+    }
+
+    public URI getTrustAnchorUri() {
+        return ofNullable(aggregatedMetadata)
+                .map(EidasMetadataConfiguration::getTrustAnchorUri)
+                .orElseGet(environment::getEidasMetadataTrustAnchorUri);
+    }
+
     public boolean isEnabled() {
         return enabled;
+    }
+
+    private EidasMetadataConfiguration createEidasMetadataConfigurationWithDefaults() {
+        return new EidasMetadataConfiguration(null, 0L, 0L, 0L, 0L, null, null, new EncodedTrustStoreConfiguration(), null);
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+import uk.gov.ida.saml.metadata.EidasMetadataConfigurationImpl;
 import uk.gov.ida.saml.metadata.EncodedTrustStoreConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.security.KeyStore;
+import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
@@ -17,18 +19,18 @@ public class EuropeanIdentityConfiguration {
 
     private String hubConnectorEntityId;
     private boolean enabled;
-    private EidasMetadataConfiguration aggregatedMetadata;
-    private HubEnvironment environment;
+    private EidasMetadataConfigurationImpl aggregatedMetadata;
+
 
     @JsonCreator
     public EuropeanIdentityConfiguration(
             @JsonProperty("hubConnectorEntityId") String hubConnectorEntityId,
             @NotNull @Valid @JsonProperty("enabled") boolean enabled,
-            @Valid @JsonProperty("aggregatedMetadata") EidasMetadataConfiguration aggregatedMetadata
+            @Valid @JsonProperty("aggregatedMetadata") EidasMetadataConfigurationImpl aggregatedMetadata
     ){
         this.enabled = enabled;
         this.hubConnectorEntityId = hubConnectorEntityId;
-        this.aggregatedMetadata = ofNullable(aggregatedMetadata).orElse(createEidasMetadataConfigurationWithDefaults());
+        this.aggregatedMetadata = ofNullable(aggregatedMetadata).orElse(new EidasMetadataConfigurationImpl());
     }
 
     public String getHubConnectorEntityId() {
@@ -37,7 +39,7 @@ public class EuropeanIdentityConfiguration {
 
     @JsonIgnore
     public void setEnvironment(HubEnvironment environment) {
-        this.environment = environment;
+        this.aggregatedMetadata.setEnvironment(environment);
     }
 
     public EidasMetadataConfiguration getAggregatedMetadata() {
@@ -45,28 +47,20 @@ public class EuropeanIdentityConfiguration {
     }
 
     public URI getMetadataSourceUri() {
-        return ofNullable(aggregatedMetadata)
-                .map(EidasMetadataConfiguration::getMetadataSourceUri)
-                .orElseGet(environment::getEidasMetadataSourceUri);
+        return aggregatedMetadata.getMetadataSourceUri();
     }
 
     public KeyStore getTrustStore() {
-        return ofNullable(aggregatedMetadata)
-                .map(EidasMetadataConfiguration::getTrustStore)
-                .orElseGet(environment::getMetadataTrustStore);
+        return aggregatedMetadata.getTrustStore();
     }
 
     public URI getTrustAnchorUri() {
-        return ofNullable(aggregatedMetadata)
-                .map(EidasMetadataConfiguration::getTrustAnchorUri)
-                .orElseGet(environment::getEidasMetadataTrustAnchorUri);
+      return aggregatedMetadata.getTrustAnchorUri();
+
     }
 
     public boolean isEnabled() {
         return enabled;
     }
 
-    private EidasMetadataConfiguration createEidasMetadataConfigurationWithDefaults() {
-        return new EidasMetadataConfiguration(null, 0L, 0L, 0L, 0L, null, null, new EncodedTrustStoreConfiguration(), null);
-    }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
@@ -11,6 +11,18 @@ import java.security.KeyStore;
 import java.util.Arrays;
 
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.DEFAULT_TRUST_STORE_PASSWORD;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.COMPLIANCE_SSO;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.COMPLIANCE_METADATA;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.PRODUCTION_SSO;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.PRODUCTION_METADATA;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.INTEGRATION_SSO;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.INTEGRATION_METADATA;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.COMPLIANCE_METADATASOURCE_URI;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.COMPLIANCE_TRUSTANCHOR_URI;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.INTEGRATION_METADATASOURCE_URI;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.INTEGRATION_TRUSTANCHOR_URI;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.PRODUCTION_METADATASOURCE_URI;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.EnvironmentUrls.PRODUCTION_TRUSTANCHOR_URI;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_HUB_TRUSTSTORE;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_IDP_TRUSTSTORE;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_METADATA_TRUSTSTORE;
@@ -20,20 +32,30 @@ import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConsta
 
 public enum HubEnvironment {
     PRODUCTION(
-            URI.create("https://www.signin.service.gov.uk/SAML2/SSO"),
-            URI.create("https://www.signin.service.gov.uk/SAML2/metadata/federation"),
+            URI.create(PRODUCTION_SSO),
+            URI.create(PRODUCTION_METADATA),
+            URI.create(PRODUCTION_METADATASOURCE_URI),
+            URI.create(PRODUCTION_TRUSTANCHOR_URI),
             PRODUCTION_METADATA_TRUSTSTORE, PRODUCTION_HUB_TRUSTSTORE, PRODUCTION_IDP_TRUSTSTORE),
     INTEGRATION(
-            URI.create("https://www.integration.signin.service.gov.uk/SAML2/SSO"),
-            URI.create("https://www.integration.signin.service.gov.uk/SAML2/metadata/federation"),
+            URI.create(INTEGRATION_SSO),
+            URI.create(INTEGRATION_METADATA),
+            URI.create(INTEGRATION_METADATASOURCE_URI),
+            URI.create(INTEGRATION_TRUSTANCHOR_URI),
             TEST_METADATA_TRUSTSTORE, TEST_HUB_TRUSTSTORE, TEST_IDP_TRUSTSTORE),
     COMPLIANCE_TOOL(
-            URI.create("https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/SSO"),
-            URI.create("https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/metadata/federation"),
+            URI.create(COMPLIANCE_SSO),
+            URI.create(COMPLIANCE_METADATA),
+            URI.create(COMPLIANCE_METADATASOURCE_URI),
+            URI.create(COMPLIANCE_TRUSTANCHOR_URI),
             TEST_METADATA_TRUSTSTORE, TEST_HUB_TRUSTSTORE, TEST_IDP_TRUSTSTORE);
+
 
     private URI ssoLocation;
     private URI metadataUri;
+
+    private URI eidasMetaDataSourceUri;
+    private URI eidasMetadataTrustAnchorUri;
     private String metadataTrustStore;
     private String hubTrustStore;
     private String idpTrustStore;
@@ -49,9 +71,11 @@ public enum HubEnvironment {
             ));
     }
 
-    HubEnvironment(URI ssoLocation, URI metadataUri, String metadataTrustStore, String hubTrustStore, String idpTrustStore) {
+    HubEnvironment(URI ssoLocation, URI metadataUri, URI eidasMetadataSourceUri, URI eidasMetadataTrustAnchorUri, String metadataTrustStore, String hubTrustStore, String idpTrustStore) {
         this.ssoLocation = ssoLocation;
         this.metadataUri = metadataUri;
+        this.eidasMetaDataSourceUri = eidasMetadataSourceUri;
+        this.eidasMetadataTrustAnchorUri = eidasMetadataTrustAnchorUri;
         this.metadataTrustStore = metadataTrustStore;
         this.hubTrustStore = hubTrustStore;
         this.idpTrustStore = idpTrustStore;
@@ -65,6 +89,13 @@ public enum HubEnvironment {
         return this.metadataUri;
     }
 
+    public URI getEidasMetadataSourceUri() {
+        return this.eidasMetaDataSourceUri;
+    }
+
+    public URI getEidasMetadataTrustAnchorUri() {
+        return this.eidasMetadataTrustAnchorUri;
+    }
     public KeyStore getMetadataTrustStore() {
         return loadTrustStore(metadataTrustStore);
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyHubConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyHubConfiguration.java
@@ -9,26 +9,28 @@ import static java.util.Optional.ofNullable;
 
 public class VerifyHubConfiguration {
 
+    private HubEnvironment hubEnvironment;
     private URI hubSsoLocation;
     private HubMetadataConfiguration hubMetadataConfiguration;
 
     public VerifyHubConfiguration(HubEnvironment hubEnvironment) {
-       this(hubEnvironment, null, null);
+        this(hubEnvironment, null, null);
     }
 
     @JsonCreator
     public VerifyHubConfiguration(
-        @JsonProperty("environment") HubEnvironment hubEnvironment,
-        @JsonProperty("ssoLocation") URI hubSsoLocation,
-        @JsonProperty("metadata") HubMetadataConfiguration hubMetadataConfiguration
+            @JsonProperty("environment") HubEnvironment hubEnvironment,
+            @JsonProperty("ssoLocation") URI hubSsoLocation,
+            @JsonProperty("metadata") HubMetadataConfiguration hubMetadataConfiguration
     ) {
+        this.hubEnvironment = hubEnvironment;
         this.hubSsoLocation = ofNullable(hubSsoLocation).orElse(hubEnvironment.getSsoLocation());
         this.hubMetadataConfiguration = ofNullable(hubMetadataConfiguration).orElse(createHubMetadataConfigurationWithDefaults());
         this.hubMetadataConfiguration.setEnvironment(hubEnvironment);
     }
 
-    private HubMetadataConfiguration createHubMetadataConfigurationWithDefaults() {
-        return new HubMetadataConfiguration(null, null, null, null, null, null, null, null, null, null);
+    public HubEnvironment getHubEnvironment() {
+        return hubEnvironment;
     }
 
     public URI getHubSsoLocation() {
@@ -37,5 +39,9 @@ public class VerifyHubConfiguration {
 
     public HubMetadataConfiguration getHubMetadataConfiguration() {
         return hubMetadataConfiguration;
+    }
+
+    private HubMetadataConfiguration createHubMetadataConfigurationWithDefaults() {
+        return new HubMetadataConfiguration(null, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
@@ -39,7 +39,7 @@ public class VerifyServiceProviderConfiguration extends Configuration {
         @JsonProperty("samlSecondaryEncryptionKey") @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlSecondaryEncryptionKey,
         @JsonProperty("msaMetadata") @NotNull @Valid Optional<MsaMetadataConfiguration> msaMetadata,
         @JsonProperty("clockSkew") @NotNull @Valid Duration clockSkew,
-        @JsonProperty("europeanIdentity") @Valid EuropeanIdentityConfiguration europeanIdentity
+        @JsonProperty("europeanIdentity") @Valid Optional<EuropeanIdentityConfiguration> europeanIdentity
     ) {
         this.serviceEntityIds = serviceEntityIds;
         this.hashingEntityId = hashingEntityId;
@@ -49,7 +49,8 @@ public class VerifyServiceProviderConfiguration extends Configuration {
         this.samlSecondaryEncryptionKey = samlSecondaryEncryptionKey;
         this.msaMetadata = msaMetadata;
         this.clockSkew = clockSkew;
-        this.europeanIdentity = Optional.ofNullable(europeanIdentity);
+        this.europeanIdentity = europeanIdentity;
+        this.europeanIdentity.ifPresent(eid -> eid.setEnvironment(verifyHubConfiguration.getHubEnvironment()));
     }
 
     public List<String> getServiceEntityIds() {

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -4,7 +4,6 @@ import common.uk.gov.ida.verifyserviceprovider.utils.EnvironmentHelper;
 import io.dropwizard.logging.DefaultLoggingFactory;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import keystore.KeyStoreResource;
 import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
@@ -15,12 +14,10 @@ import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfi
 
 import java.util.HashMap;
 
-import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.apache.xml.security.utils.Base64.decode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
-import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 
 public class ApplicationConfigurationFeatureTests {
 
@@ -29,22 +26,10 @@ public class ApplicationConfigurationFeatureTests {
 
     @Before
     public void setUp() {
-        KeyStoreResource keyStoreResource = aKeyStoreResource()
-            .withCertificate("any-alias", aCertificate().build().getCertificate())
-            .build();
-        keyStoreResource.create();
         application = new DropwizardAppRule<>(
             VerifyServiceProviderApplication.class,
                 "verify-service-provider.yml",
-            ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
-            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", keyStoreResource.getAbsolutePath()),
-            ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", keyStoreResource.getPassword()),
-            ConfigOverride.config("europeanIdentity.enabled", "false"),
-            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
-            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustAnchorUri", "http://dummy.com"),
-            ConfigOverride.config("europeanIdentity.aggregatedMetadata.metadataSourceUri", "http://dummy.com"),
-            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.path", keyStoreResource.getAbsolutePath()),
-            ConfigOverride.config("europeanIdentity.aggregatedMetadata.trustStore.password", keyStoreResource.getPassword())
+            ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG")
         );
     }
 
@@ -81,6 +66,14 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getSamlPrimaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(30));
+        assertThat(configuration.getEuropeanIdentity().isPresent()).isTrue();
+        assertThat(configuration.getEuropeanIdentity().get().getMetadataSourceUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataSourceUri());
+        assertThat(configuration.getEuropeanIdentity().get().getTrustAnchorUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataTrustAnchorUri());
+        assertThat(configuration.getEuropeanIdentity().get().getAggregatedMetadata().getTrustStore().getCertificate("idaca").toString())
+                .isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getMetadataTrustStore().getCertificate("idaca").toString());
+        assertThat(configuration.getEuropeanIdentity().get().getAggregatedMetadata().getTrustStore().getCertificate("idametadata").toString())
+                .isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getMetadataTrustStore().getCertificate("idametadata").toString());
+
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -1,0 +1,133 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import certificates.values.CACertificates;
+import keystore.KeyStoreResource;
+import keystore.builders.KeyStoreResourceBuilder;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.cert.Certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.utils.DefaultObjectMapper.OBJECT_MAPPER;
+
+public class EuropeanIdentityConfigurationTest {
+
+    private String config;
+    private static final KeyStoreResource keyStore = KeyStoreResourceBuilder.aKeyStoreResource()
+            .withCertificate("metadataCA", CACertificates.TEST_METADATA_CA)
+            .withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+
+    @Before
+    public void setUp() {
+        keyStore.create();
+        config = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                    .put("trustAnchorUri", "http://example.com")
+                    .put("trustStore", new JSONObject()
+                            .put("path",keyStore.getAbsolutePath())
+                            .put("password",keyStore.getPassword())
+                    )
+                ).toString();
+    }
+
+    @Test
+    public void shouldUseTestTrustStoreWithIntegrationTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToIntegration() throws Exception {
+
+        Certificate testEntryCert =  keyStore.getKeyStore().getCertificate("metadataCA");
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
+    }
+
+    @Test
+    public void shouldUseTrustStoreWithProductionTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToProduction() throws Exception {
+
+        Certificate testEntryCert =  keyStore.getKeyStore().getCertificate("metadataCA");
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.PRODUCTION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
+    }
+
+    @Test
+    public void shouldUseTestTrustStoreWithComplianceTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToCompliance() throws Exception {
+
+        Certificate testEntryCert = keyStore.getKeyStore().getCertificate("metadataCA");
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.COMPLIANCE_TOOL);
+        Certificate europeanConfigCert = europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
+    }
+    @Test
+    public void shouldReadTrustAnchorAtUriGivenEidasIsEnabledWithHubEnvironmentSetToIntegrationWhenTrustAnchorUriHasBeenSpecified() throws IOException {
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(URI.create("http://example.com"));
+    }
+
+    @Test @Ignore
+    public void shouldReadTrustAnchorAtUriGivenEidasIsEnabledWithoutHubEnvironmentSetToIntegrationWhenTrustAnchorUriHasBeenSpecified() throws IOException {
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(URI.create("http://example.com"));
+    }
+
+    @Test
+    public void shouldReadHubEnvironmentTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToIntegrationWhenNoTrustAnchorUriHasBeenSpecified() throws IOException {
+        config = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                        .put("trustStore", new JSONObject()
+                                .put("path",keyStore.getAbsolutePath())
+                                .put("password",keyStore.getPassword())
+                        )
+                ).toString();
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        EidasMetadataConfiguration eidasMetadataConfiguration = europeanIdentityConfiguration.getAggregatedMetadata();
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+
+        assertThat(eidasMetadataConfiguration.getTrustAnchorUri()).isNotEqualTo(URI.create("http://example.com"));
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void shouldErrorWhenReadingTrustAnchorGivenEidasIsEnabledWithNoSpecifiedTrustAnchorUriAndNoSpecifiedEnvironment() throws IOException {
+        config = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                        .put("trustStore", new JSONObject()
+                                .put("path",keyStore.getAbsolutePath())
+                                .put("password",keyStore.getPassword())
+                        )
+                ).toString();
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri());
+    }
+}

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -52,7 +52,7 @@ public class EuropeanIdentityConfigurationTest {
                 .put("enabled", true)
                 .put("hubConnectorEntityId","some-entity-id")
                 .put("aggregatedMetadata", new JSONObject()
-                        .put("trustStoreConfiguration", new JSONObject()
+                        .put("trustStore", new JSONObject()
                                 .put("path", overridenKeyStoreResource.getAbsolutePath())
                                 .put("password", overridenKeyStoreResource.getPassword())
                         )

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -1,133 +1,212 @@
 package uk.gov.ida.verifyserviceprovider.configuration;
 
 import certificates.values.CACertificates;
+import helpers.ResourceHelpers;
 import keystore.KeyStoreResource;
 import keystore.builders.KeyStoreResourceBuilder;
 import org.json.JSONObject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
+import uk.gov.ida.truststore.KeyStoreLoader;
 
-import java.io.IOException;
-import java.net.URI;
+import java.security.KeyStore;
 import java.security.cert.Certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.*;
 import static uk.gov.ida.verifyserviceprovider.utils.DefaultObjectMapper.OBJECT_MAPPER;
 
 public class EuropeanIdentityConfigurationTest {
 
-    private String config;
-    private static final KeyStoreResource keyStore = KeyStoreResourceBuilder.aKeyStoreResource()
-            .withCertificate("metadataCA", CACertificates.TEST_METADATA_CA)
-            .withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+    public static final String IDAMETADATA = "Idametadata";
+    public static final String IDACA = "Idaca";
+    public static final String OVERRIDENMETADATACA = "overridenmetadataca";
+    public static final String OVERRIDENROOTCA = "overridenrootca";
+    private final String overridenTrustAnchorUri = "http://overriden.trustanchoruri.example.com";
+    private final String overridenMetadataSourceUri ="http://overriden.metadatsourceuri.example.com";
+    private String configEnabledOnly, configWithTrustAnchorUriOnly,configWithTrustStoreOnlyDefined, configWithWithMetadataSourceUri;
+
+    private static KeyStoreResource overridenKeyStoreResource;
+
+    private String configWithEmptyAggregataMetadata;
+    public static final String IDAMETADATAG2 = "idametadatag2";
 
     @Before
     public void setUp() {
-        keyStore.create();
-        config = new JSONObject()
+        overridenKeyStoreResource = KeyStoreResourceBuilder.aKeyStoreResource()
+                .withCertificate(OVERRIDENMETADATACA, CACertificates.TEST_METADATA_CA)
+                .withCertificate(OVERRIDENROOTCA, CACertificates.TEST_ROOT_CA).build();
+
+        overridenKeyStoreResource.create();
+
+        configEnabledOnly = new JSONObject().put("enabled", true).toString();
+
+        configWithTrustAnchorUriOnly = new JSONObject()
                 .put("enabled", true)
                 .put("hubConnectorEntityId","some-entity-id")
                 .put("aggregatedMetadata", new JSONObject()
-                    .put("trustAnchorUri", "http://example.com")
-                    .put("trustStore", new JSONObject()
-                            .put("path",keyStore.getAbsolutePath())
-                            .put("password",keyStore.getPassword())
-                    )
+                    .put("trustAnchorUri", overridenTrustAnchorUri)
                 ).toString();
+
+        configWithTrustStoreOnlyDefined = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                        .put("trustStoreConfiguration", new JSONObject()
+                                .put("path", overridenKeyStoreResource.getAbsolutePath())
+                                .put("password", overridenKeyStoreResource.getPassword())
+                        )
+                ).toString();
+
+        configWithWithMetadataSourceUri = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                        .put("metadataSourceUri",overridenMetadataSourceUri)
+                ).toString();
+
+        configWithEmptyAggregataMetadata = new JSONObject()
+                .put("enabled", true)
+                .put("hubConnectorEntityId","some-entity-id")
+                .put("aggregatedMetadata", new JSONObject()
+                ).toString();
+
+    }
+    @Test
+    public void shouldUseTestTrustStoreWithIntegrationTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToIntegration() throws Exception {
+        KeyStore integrationKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  integrationKeyStore.getCertificate(IDAMETADATA);
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configEnabledOnly, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATA);
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
     }
 
     @Test
-    public void shouldUseTestTrustStoreWithIntegrationTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToIntegration() throws Exception {
+    public void shouldUseIntegrationEnvironmentConfigExceptOverriddenTrustAnchorUri() throws Exception {
+        KeyStore integrationKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  integrationKeyStore.getCertificate(IDAMETADATA);
 
-        Certificate testEntryCert =  keyStore.getKeyStore().getCertificate("metadataCA");
-
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configWithTrustAnchorUriOnly, EuropeanIdentityConfiguration.class);
         europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
-        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATA);
 
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATA)).isTrue();
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
-        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
+        assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri().toString()).isEqualTo(overridenTrustAnchorUri);
+        assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
+    }
+
+    @Test
+    public void shouldUseIntegrationEnvironmentConfigExceptOverriddenWithTrustStoreOnlyDefined() throws Exception {
+        KeyStore integrationKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  integrationKeyStore.getCertificate(IDAMETADATA);
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configWithTrustStoreOnlyDefined, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(OVERRIDENMETADATACA);
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(OVERRIDENROOTCA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(OVERRIDENMETADATACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isNotEqualTo(integrationEntryCert);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
+        assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
+    }
+
+    @Test
+    public void shouldUseIntegrationEnvironmentConfigExceptOverriddenWithMetadataSourceUriOnly() throws Exception {
+        KeyStore integrationKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  integrationKeyStore.getCertificate(IDAMETADATA);
+
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configWithWithMetadataSourceUri, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATA);
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
+        assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overridenMetadataSourceUri);
+
     }
 
     @Test
     public void shouldUseTrustStoreWithProductionTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToProduction() throws Exception {
 
-        Certificate testEntryCert =  keyStore.getKeyStore().getCertificate("metadataCA");
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
-        europeanIdentityConfiguration.setEnvironment(HubEnvironment.PRODUCTION);
-        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+        KeyStore productionKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(PRODUCTION_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  productionKeyStore.getCertificate(IDAMETADATAG2);
 
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configEnabledOnly, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.PRODUCTION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATAG2);
+        assertThat(productionKeyStore.containsAlias(IDAMETADATAG2)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATAG2)).isTrue();
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
-        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
+        assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
     }
 
     @Test
     public void shouldUseTestTrustStoreWithComplianceTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToCompliance() throws Exception {
+        KeyStore integrationKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate integrationEntryCert =  integrationKeyStore.getCertificate(IDAMETADATA);
 
-        Certificate testEntryCert = keyStore.getKeyStore().getCertificate("metadataCA");
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configEnabledOnly, EuropeanIdentityConfiguration.class);
         europeanIdentityConfiguration.setEnvironment(HubEnvironment.COMPLIANCE_TOOL);
-        Certificate europeanConfigCert = europeanIdentityConfiguration.getTrustStore().getCertificate("metadataCA");
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATA);
 
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("rootCA")).isTrue();
-        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias("metadataCA")).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATA)).isTrue();
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
-        assertThat(europeanConfigCert).isEqualTo(testEntryCert);
-    }
-    @Test
-    public void shouldReadTrustAnchorAtUriGivenEidasIsEnabledWithHubEnvironmentSetToIntegrationWhenTrustAnchorUriHasBeenSpecified() throws IOException {
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
-        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
-
-        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(URI.create("http://example.com"));
-    }
-
-    @Test @Ignore
-    public void shouldReadTrustAnchorAtUriGivenEidasIsEnabledWithoutHubEnvironmentSetToIntegrationWhenTrustAnchorUriHasBeenSpecified() throws IOException {
-
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
-
-        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(URI.create("http://example.com"));
+        assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
     }
 
     @Test
-    public void shouldReadHubEnvironmentTrustAnchorGivenEidasIsEnabledWithHubEnvironmentSetToIntegrationWhenNoTrustAnchorUriHasBeenSpecified() throws IOException {
-        config = new JSONObject()
-                .put("enabled", true)
-                .put("hubConnectorEntityId","some-entity-id")
-                .put("aggregatedMetadata", new JSONObject()
-                        .put("trustStore", new JSONObject()
-                                .put("path",keyStore.getAbsolutePath())
-                                .put("password",keyStore.getPassword())
-                        )
-                ).toString();
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
-        EidasMetadataConfiguration eidasMetadataConfiguration = europeanIdentityConfiguration.getAggregatedMetadata();
-        europeanIdentityConfiguration.setEnvironment(HubEnvironment.INTEGRATION);
+    public void shouldUseProductionEnvironmentConfigExceptOverriddenWithMetadataSourceUriOnly() throws Exception {
+        KeyStore productionKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(PRODUCTION_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate productionEntryCert =  productionKeyStore.getCertificate(IDAMETADATAG2);
 
-        assertThat(eidasMetadataConfiguration.getTrustAnchorUri()).isNotEqualTo(URI.create("http://example.com"));
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configWithWithMetadataSourceUri, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.PRODUCTION);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATAG2);
+
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATAG2)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(productionEntryCert);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.PRODUCTION.getEidasMetadataTrustAnchorUri());
+        assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overridenMetadataSourceUri);
     }
 
+    @Test
+    public void shouldUseComplianceEnvironmentConfigExceptOverriddenWithMetadataSourceUriOnly() throws Exception {
+        KeyStore complianceKeyStore = new KeyStoreLoader().load(ResourceHelpers.resourceFilePath(TEST_METADATA_TRUSTSTORE),DEFAULT_TRUST_STORE_PASSWORD);
+        Certificate complianceEntryCert =  complianceKeyStore.getCertificate(IDAMETADATA);
 
-    @Test(expected = NullPointerException.class)
-    public void shouldErrorWhenReadingTrustAnchorGivenEidasIsEnabledWithNoSpecifiedTrustAnchorUriAndNoSpecifiedEnvironment() throws IOException {
-        config = new JSONObject()
-                .put("enabled", true)
-                .put("hubConnectorEntityId","some-entity-id")
-                .put("aggregatedMetadata", new JSONObject()
-                        .put("trustStore", new JSONObject()
-                                .put("path",keyStore.getAbsolutePath())
-                                .put("password",keyStore.getPassword())
-                        )
-                ).toString();
+        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(configWithWithMetadataSourceUri, EuropeanIdentityConfiguration.class);
+        europeanIdentityConfiguration.setEnvironment(HubEnvironment.COMPLIANCE_TOOL);
+        Certificate europeanConfigCert =  europeanIdentityConfiguration.getTrustStore().getCertificate(IDAMETADATA);
 
-        EuropeanIdentityConfiguration europeanIdentityConfiguration = OBJECT_MAPPER.readValue(config, EuropeanIdentityConfiguration.class);
-        assertThat(europeanIdentityConfiguration.getTrustAnchorUri());
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDACA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().containsAlias(IDAMETADATA)).isTrue();
+        assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
+        assertThat(europeanConfigCert).isEqualTo(complianceEntryCert);
+
+        assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataTrustAnchorUri());
+        assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overridenMetadataSourceUri);
+
     }
 }

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -13,7 +13,9 @@ import java.security.KeyStore;
 import java.security.cert.Certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.*;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.DEFAULT_TRUST_STORE_PASSWORD;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_METADATA_TRUSTSTORE;
+import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.TEST_METADATA_TRUSTSTORE;
 import static uk.gov.ida.verifyserviceprovider.utils.DefaultObjectMapper.OBJECT_MAPPER;
 
 public class EuropeanIdentityConfigurationTest {

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderConfigurationTest.java
@@ -135,7 +135,7 @@ public class VerifyServiceProviderConfigurationTest {
                 mock(PrivateKey.class),
                 Optional.empty(),
                 new Duration(1000L),
-                mock(EuropeanIdentityConfiguration.class)
+                Optional.ofNullable(mock(EuropeanIdentityConfiguration.class))
         );
     }
 

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -52,9 +52,11 @@ europeanIdentity:
   enabled: ${EUROPEAN_IDENTITY_ENABLED:-false}
   hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
   aggregatedMetadata:
-    trustAnchorUri: ${TRUST_ANCHOR_URI:-"http://example"}
-    metadataSourceUri: ${METADATA_SOURCE_URI:-"http://example"}
+    # trustAnchorUri is the URL location of the trustAnchor (for example https://example.com)
+    trustAnchorUri: ${TRUST_ANCHOR_URI:-}
+    # metadataSourceUri is the URL location of the metadataSourceUri (for example https://example.com)
+    metadataSourceUri: ${METADATA_SOURCE_URI:-}
     trustStore:
-      path: ${TRUSTSTORE_PATH}/ida_metadata_truststore.ts
-      password: ${TRUSTSTORE_PASSWORD}
+      path: ${TRUSTSTORE_PATH:-}
+      password: ${TRUSTSTORE_PASSWORD:-}
     jerseyClientName: trust-anchor-client

--- a/verify-service-provider.yml
+++ b/verify-service-provider.yml
@@ -51,12 +51,3 @@ samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
 europeanIdentity:
   enabled: ${EUROPEAN_IDENTITY_ENABLED:-false}
   hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
-  aggregatedMetadata:
-    # trustAnchorUri is the URL location of the trustAnchor (for example https://example.com)
-    trustAnchorUri: ${TRUST_ANCHOR_URI:-}
-    # metadataSourceUri is the URL location of the metadataSourceUri (for example https://example.com)
-    metadataSourceUri: ${METADATA_SOURCE_URI:-}
-    trustStore:
-      path: ${TRUSTSTORE_PATH:-}
-      password: ${TRUSTSTORE_PASSWORD:-}
-    jerseyClientName: trust-anchor-client


### PR DESCRIPTION
- Support for EIDAS is based on whether the VSP has an EIDAS configuration
- EIDAS service is enabled when it flag is set to true
- Added tests for the above

Co-authored-by: Amrit Sidhu <amrit.sidhu@digital.cabinet-office.gov.uk>