### PR TITLE
EID-1325: Add RequestedAuthnContext to AuthnRequest

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactory.java
@@ -5,14 +5,19 @@ import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.common.SAMLRuntimeException;
 import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.EncryptedAttribute;
 import org.opensaml.saml.saml2.core.Extensions;
 import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.core.impl.AttributeBuilder;
+import org.opensaml.saml.saml2.core.impl.AuthnContextClassRefBuilder;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
 import org.opensaml.saml.saml2.core.impl.ExtensionsBuilder;
 import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
+import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import org.opensaml.xmlsec.encryption.support.EncryptionException;
@@ -21,6 +26,7 @@ import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
 import uk.gov.ida.saml.core.extensions.versioning.Version;
 import uk.gov.ida.saml.core.extensions.versioning.VersionImpl;
 import uk.gov.ida.saml.core.extensions.versioning.application.ApplicationVersion;
@@ -36,8 +42,11 @@ import uk.gov.ida.verifyserviceprovider.factories.EncrypterFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class AuthnRequestFactory {
 
@@ -61,12 +70,22 @@ public class AuthnRequestFactory {
     }
 
     public AuthnRequest build(LevelOfAssurance levelOfAssurance, String serviceEntityId) {
+        List<String> authnContexts = new ArrayList<>();
+        switch (levelOfAssurance) {
+            case LEVEL_1:
+                authnContexts.add(IdaAuthnContext.LEVEL_1_AUTHN_CTX);
+            case LEVEL_2:
+                authnContexts.add(IdaAuthnContext.LEVEL_2_AUTHN_CTX);
+                break;
+        }
+
         AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
         authnRequest.setID(String.format("_%s", UUID.randomUUID()));
         authnRequest.setIssueInstant(DateTime.now());
         authnRequest.setForceAuthn(false);
         authnRequest.setDestination(destination.toString());
         authnRequest.setExtensions(createExtensions());
+        authnRequest.setRequestedAuthnContext(createRequestedAuthnContext(authnContexts));
 
         Issuer issuer = new IssuerBuilder().buildObject();
         issuer.setValue(serviceEntityId);
@@ -82,6 +101,18 @@ public class AuthnRequestFactory {
         }
 
         return authnRequest;
+    }
+
+    private RequestedAuthnContext createRequestedAuthnContext(List<String> authnContexts) {
+        RequestedAuthnContext requestedAuthnContext= new RequestedAuthnContextBuilder().buildObject();
+        List<AuthnContextClassRef> authnContextClassRefs = authnContexts.stream().map((a) -> {
+            AuthnContextClassRef authnContextClassRef = new AuthnContextClassRefBuilder().buildObject();
+            authnContextClassRef.setAuthnContextClassRef(a);
+            return authnContextClassRef;
+        }).collect(Collectors.toList());
+        requestedAuthnContext.getAuthnContextClassRefs().addAll(authnContextClassRefs);
+        requestedAuthnContext.setComparison(AuthnContextComparisonTypeEnumeration.EXACT);
+        return requestedAuthnContext;
     }
 
     private Extensions createExtensions() {

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactoryTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactoryTest.java
@@ -8,6 +8,7 @@ import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.EncryptedAttribute;
 import org.opensaml.saml.saml2.core.Extensions;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.saml.saml2.encryption.Encrypter;
 import org.opensaml.security.credential.BasicCredential;
@@ -17,6 +18,7 @@ import uk.gov.ida.common.shared.security.PrivateKeyStore;
 import uk.gov.ida.common.shared.security.PublicKeyFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
 import uk.gov.ida.saml.core.extensions.versioning.Version;
 import uk.gov.ida.saml.core.test.PrivateKeyStoreFactory;
 import uk.gov.ida.saml.core.test.TestEntityIds;
@@ -128,6 +130,27 @@ public class AuthnRequestFactoryTest {
         factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
 
         verify(manifestReader, times(1)).getAttributeValueFor(VerifyServiceProviderApplication.class, "Version");
+    }
+
+    @Test
+    public void shouldContainBothAuthnContextClassRefsForLOA1() {
+        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_1, SERVICE_ENTITY_ID);
+        RequestedAuthnContext requestedAuthnContext = authnRequest.getRequestedAuthnContext();
+
+        assertThat(requestedAuthnContext).isNotNull();
+        assertThat(requestedAuthnContext.getAuthnContextClassRefs().size()).isEqualTo(2);
+        assertThat(requestedAuthnContext.getAuthnContextClassRefs().get(0).getAuthnContextClassRef()).isEqualTo(IdaAuthnContext.LEVEL_1_AUTHN_CTX);
+        assertThat(requestedAuthnContext.getAuthnContextClassRefs().get(1).getAuthnContextClassRef()).isEqualTo(IdaAuthnContext.LEVEL_2_AUTHN_CTX);
+    }
+
+    @Test
+    public void shouldOnlyContainLevel2AuthnContextClassRefForLOA2() {
+        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        RequestedAuthnContext requestedAuthnContext = authnRequest.getRequestedAuthnContext();
+
+        assertThat(requestedAuthnContext).isNotNull();
+        assertThat(requestedAuthnContext.getAuthnContextClassRefs().size()).isEqualTo(1);
+        assertThat(requestedAuthnContext.getAuthnContextClassRefs().get(0).getAuthnContextClassRef()).isEqualTo(IdaAuthnContext.LEVEL_2_AUTHN_CTX);
     }
 
     private BasicCredential createBasicCredential() {


### PR DESCRIPTION
The `levelOfAssurance` parameter sent to the `/generate-request` endpoint
was being ignored. This change adds the corresponding AuthnContextClassRef(s) to
the RequestedAuthnContext of the AuthnRequest generated by the VSP.

In the case of LOA1, we need to add both the level 1 and level 2
AuthnContextClassRefs while for LOA2 we only need the level 2
AuthnContextClassRef.