### PR TITLE
NjRC8QiD: Add LOA to Compliance Tool MDS

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAddress;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAttribute;
@@ -116,6 +117,7 @@ public class NonMatchingAcceptanceTest {
                     new MatchingAddress(true, standardFromDate, standardToDate, "E1 8QS", Arrays.asList("The White Chapel Building" ,"10 Whitechapel High Street"), null, null),
                     new MatchingAddress(true, laterFromDate, null, "E1 8QX", Arrays.asList("The White Chapel Building 2" ,"11 Whitechapel High Street"), null, null)
             ),
+            AuthnContext.LEVEL_1,
             expectedPid
         );
 
@@ -151,8 +153,10 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smythington", true, expectedLaterFromDateString, expectedLaterToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("dateOfBirth", "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
+
+        // Checking the address is disabled due to the bug described on Trello card UxVgyEvD
+        //MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
+        //MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
     }
 
     @Test
@@ -172,6 +176,7 @@ public class NonMatchingAcceptanceTest {
                 new MatchingAttribute("NOT_SPECIFIED", true, standardFromDate, standardToDate),
                 null,
                 singletonList(new MatchingAddress(true, standardFromDate, standardToDate, "E1 8QS", Arrays.asList("The White Chapel Building" ,"10 Whitechapel High Street"), null, null)),
+                AuthnContext.LEVEL_1,
                 expectedPid
         );
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -153,10 +153,8 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smythington", true, expectedLaterFromDateString, expectedLaterToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("dateOfBirth", "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-
-        // Checking the address is disabled due to the bug described on Trello card UxVgyEvD
-        //MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
-        //MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
     }
 
     @Test

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolV2InitialisationRequestBuilder.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolV2InitialisationRequestBuilder.java
@@ -3,6 +3,7 @@ package uk.gov.ida.verifyserviceprovider.builders;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAddress;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAttribute;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDataset;
+import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDatasetBuilder;
 
 import javax.ws.rs.client.Entity;
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public class ComplianceToolV2InitialisationRequestBuilder {
     private String assertionConsumerServiceUrl = "http://verify-service-provider/response";
     private String signingCertificate = TEST_RP_PUBLIC_SIGNING_CERT;
     private String encryptionCertificate = TEST_RP_PUBLIC_ENCRYPTION_CERT;
-    private MatchingDataset matchingDataset = new MatchingDataset(new MatchingAttribute("Bob", true, LocalDateTime.now().minusDays(30), LocalDateTime.now()), null, singletonList(new MatchingAttribute("Smith", true, LocalDateTime.now().minusDays(30), LocalDateTime.now())), new MatchingAttribute("NOT_SPECIFIED", true, LocalDateTime.now().minusDays(30), LocalDateTime.now()), null, singletonList(new MatchingAddress(true, LocalDateTime.now().minusDays(30), LocalDateTime.now(), "E1 8QS", Arrays.asList("The White Chapel Building" ,"10 Whitechapel High Street"), null, null)), UUID.randomUUID().toString());
+    private MatchingDataset matchingDataset = new MatchingDatasetBuilder().build();
 
     public static ComplianceToolV2InitialisationRequestBuilder aComplianceToolV2InitialisationRequest() {
         return new ComplianceToolV2InitialisationRequestBuilder();

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDataset.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDataset.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
+import uk.gov.ida.saml.core.domain.AuthnContext;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -45,6 +46,11 @@ public class MatchingDataset {
     @NotNull
     @Valid
     @JsonProperty
+    private AuthnContext levelOfAssurance;
+
+    @NotNull
+    @Valid
+    @JsonProperty
     private String persistentId;
 
     public MatchingDataset() {}
@@ -55,6 +61,7 @@ public class MatchingDataset {
                            MatchingAttribute gender,
                            MatchingAttribute dateOfBirth,
                            List<MatchingAddress> addresses,
+                           AuthnContext levelOfAssurance,
                            String persistentId) {
         this.firstName = firstName;
         this.middleNames = middleNames;
@@ -62,6 +69,7 @@ public class MatchingDataset {
         this.gender = gender;
         this.dateOfBirth = dateOfBirth;
         this.addresses = addresses;
+        this.levelOfAssurance = levelOfAssurance;
         this.persistentId = persistentId;
     }
 
@@ -87,6 +95,10 @@ public class MatchingDataset {
 
     public List<MatchingAddress> getAddresses() {
         return addresses;
+    }
+
+    public AuthnContext getLevelOfAssurance() {
+        return levelOfAssurance;
     }
 
     public String getPersistentId() {

--- a/src/main/resources/default-test-identity-dataset.json
+++ b/src/main/resources/default-test-identity-dataset.json
@@ -51,5 +51,6 @@
       "uprn": null
     }
   ],
+  "levelOfAssurance": "LEVEL_1",
   "persistentId": "ff5de5e2-6070-44e7-985b-2079637b878e"
 }

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDatasetBuilder.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/dto/MatchingDatasetBuilder.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.verifyserviceprovider.compliance.dto;
 
+import uk.gov.ida.saml.core.domain.AuthnContext;
+
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +28,7 @@ public class MatchingDatasetBuilder {
             null,
             null
     ));
+    private AuthnContext levelOfAssurance = AuthnContext.LEVEL_1;
     private String persistentId = UUID.randomUUID().toString();
 
     public MatchingDatasetBuilder withFirstName(MatchingAttribute firstName) {
@@ -101,13 +104,18 @@ public class MatchingDatasetBuilder {
         return this;
     }
 
+    public MatchingDatasetBuilder withLevelOfAssurance(AuthnContext levelOfAssurance) {
+        this.levelOfAssurance = levelOfAssurance;
+        return this;
+    }
+
     public MatchingDatasetBuilder withPersistentId(String persistentId) {
         this.persistentId = persistentId;
         return this;
     }
 
     public MatchingDataset build() {
-        return new MatchingDataset(firstName, middleNames, surnames, gender, dateOfBirth, addresses, persistentId);
+        return new MatchingDataset(firstName, middleNames, surnames, gender, dateOfBirth, addresses, levelOfAssurance, persistentId);
     }
 
     public MatchingDatasetBuilder withEidasSurname(String value) {


### PR DESCRIPTION
We forgot to include the LevelOfAssurance in the DTO for the matching dataset used to initiate the Compliance Tool when running the VSP in development mode.