### PR TITLE
 zEyIoEnS: Return most attributes with their historical values

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -15,6 +15,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+import org.bouncycastle.util.Arrays;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,11 +50,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 import static uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker.checkMdsValueInArrayAttributeWithoutDates;
-import static uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker.checkMdsValueOfAttributeWithoutDates;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.VERIFIED_USER_ON_SERVICE_WITH_NON_MATCH_SETTING_ID;
 
 public class ComplianceToolModeAcceptanceTest {
 
+    public static final String[] COMMON_FIELDS = {"firstNames", "middleNames", "surnames", "datesOfBirth", "addresses"};
     private static String COMPLIANCE_TOOL_HOST = "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk";
 
     private static final KeyStoreResource KEY_STORE_RESOURCE = aKeyStoreResource()
@@ -161,7 +162,7 @@ public class ComplianceToolModeAcceptanceTest {
         JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
-        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "gender", "addresses");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder(Arrays.append(COMMON_FIELDS, "gender"));
 
         checkMatchingDatasetMatches(attributes, matchingDataset);
 
@@ -222,7 +223,7 @@ public class ComplianceToolModeAcceptanceTest {
         JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
-        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "gender", "addresses");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder(Arrays.append(COMMON_FIELDS, "gender"));
 
         checkMatchingDatasetMatches(attributes, newMatchingDataset);
 
@@ -271,10 +272,10 @@ public class ComplianceToolModeAcceptanceTest {
         JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
-        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "addresses");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder(COMMON_FIELDS);
 
-        checkMdsValueOfAttributeWithoutDates("firstName", matchingDataset.getFirstName().getValue(), matchingDataset.getFirstName().isVerified(), attributes);
-        checkMdsValueOfAttributeWithoutDates("dateOfBirth", matchingDataset.getDateOfBirth().getValue(), matchingDataset.getDateOfBirth().isVerified(), attributes);
+        checkMdsValueInArrayAttributeWithoutDates("firstNames", 0, matchingDataset.getFirstName().getValue(), matchingDataset.getFirstName().isVerified(), attributes);
+        checkMdsValueInArrayAttributeWithoutDates("datesOfBirth", 0, matchingDataset.getDateOfBirth().getValue(), matchingDataset.getDateOfBirth().isVerified(), attributes);
         checkMdsValueInArrayAttributeWithoutDates("surnames", 0, matchingDataset.getSurnames().get(0).getValue(), matchingDataset.getSurnames().get(0).isVerified(), attributes);
         checkMdsValueInArrayAttributeWithoutDates("middleNames", 0, matchingDataset.getMiddleNames().getValue(), matchingDataset.getMiddleNames().isVerified(), attributes);
         assertThat(attributes.getJSONArray("addresses")).isEmpty();
@@ -286,11 +287,11 @@ public class ComplianceToolModeAcceptanceTest {
     }
 
     private void checkMatchingDatasetMatches(JSONObject attributes, MatchingDataset matchingDataset) {
-        checkMatchingDatasetAttribute(attributes, "firstName", matchingDataset.getFirstName());
+        checkMatchingDatasetListAttribute(attributes, "firstNames", 0, matchingDataset.getFirstName());
         checkMatchingDatasetListAttribute(attributes, "middleNames", 0, matchingDataset.getMiddleNames());
         checkMatchingDatasetListAttribute(attributes, "surnames", 0, matchingDataset.getSurnames());
         checkMatchingDatasetListAttribute(attributes, "surnames", 1, matchingDataset.getSurnames());
-        checkMatchingDatasetAttribute(attributes, "dateOfBirth", matchingDataset.getDateOfBirth());
+        checkMatchingDatasetListAttribute(attributes, "datesOfBirth", 0, matchingDataset.getDateOfBirth());
         checkMatchingDatasetAttribute(attributes, "gender", matchingDataset.getGender());
         checkMatchingDatasetAddress(attributes, 0, matchingDataset.getAddresses());
     }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -307,7 +307,7 @@ public class ComplianceToolModeAcceptanceTest {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String fromDate = address.getFrom().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
         String toDate = address.getTo().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        MdsValueChecker.checkMdsValueOfAddress(index, address.getLines(), address.getPostCode().orElse(null), address.getInternationalPostCode().orElse(""), address.isVerified(), fromDate, toDate, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(index, address.getLines(), address.getPostCode(), address.getInternationalPostCode(), address.isVerified(), fromDate, toDate, attributes);
     }
 
     private void checkMatchingDatasetListAttribute(JSONObject attributes, String attributeName, int index, MatchingAttribute expectedAttribute) {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -39,10 +39,12 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.client.Entity.json;
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
@@ -289,8 +291,12 @@ public class ComplianceToolModeAcceptanceTest {
     private void checkMatchingDatasetMatches(JSONObject attributes, MatchingDataset matchingDataset) {
         checkMatchingDatasetListAttribute(attributes, "firstNames", 0, matchingDataset.getFirstName());
         checkMatchingDatasetListAttribute(attributes, "middleNames", 0, matchingDataset.getMiddleNames());
-        checkMatchingDatasetListAttribute(attributes, "surnames", 0, matchingDataset.getSurnames());
-        checkMatchingDatasetListAttribute(attributes, "surnames", 1, matchingDataset.getSurnames());
+        List<MatchingAttribute> sortedSurnames = matchingDataset.getSurnames()
+                .stream()
+                .sorted(Comparator.comparing(MatchingAttribute::getFrom, Comparator.reverseOrder()))
+                .collect(Collectors.toList());
+        checkMatchingDatasetListAttribute(attributes, "surnames", 0, sortedSurnames);
+        checkMatchingDatasetListAttribute(attributes, "surnames", 1, sortedSurnames);
         checkMatchingDatasetListAttribute(attributes, "datesOfBirth", 0, matchingDataset.getDateOfBirth());
         checkMatchingDatasetAttribute(attributes, "gender", matchingDataset.getGender());
         checkMatchingDatasetAddress(attributes, 0, matchingDataset.getAddresses());

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -38,6 +38,7 @@ import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.*;
 
 public class NonMatchingAcceptanceTest {
 
+    public static final String[] COMMON_ATTRIBUTES = {"firstNames", "middleNames", "surnames", "datesOfBirth", "gender", "addresses"};
     @ClassRule
     public static MockMsaServer msaServer = new MockMsaServer();
 
@@ -137,7 +138,7 @@ public class NonMatchingAcceptanceTest {
         JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
-        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "dateOfBirth", "gender", "addresses");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder(COMMON_ATTRIBUTES);
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
@@ -145,11 +146,11 @@ public class NonMatchingAcceptanceTest {
         String expectedLaterFromDateString = laterFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
         String expectedLaterToDateString = laterToDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
 
-        MdsValueChecker.checkMdsValueOfAttribute("firstName", "Bob", true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueInArrayAttribute("firstNames", 0, "Bob", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("middleNames", 0, "Montgomery", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smith", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smythington", true, expectedLaterFromDateString, expectedLaterToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAttribute("dateOfBirth", "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueInArrayAttribute("datesOfBirth", 0, "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
@@ -197,15 +198,15 @@ public class NonMatchingAcceptanceTest {
         assertThat(jsonResponse.getString("levelOfAssurance")).isEqualTo(LEVEL_1.name());
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
-        assertThat(attributes.keys()).containsExactlyInAnyOrder("firstName", "middleNames", "surnames", "gender", "addresses");
+        assertThat(attributes.keys()).containsExactlyInAnyOrder(COMMON_ATTRIBUTES);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
         String expectedToDateString = standardToDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
 
-        MdsValueChecker.checkMdsValueOfAttribute("firstName", "Bob", true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueInArrayAttribute("firstNames", 0, "Bob", true, expectedFromDateString, expectedToDateString, attributes);
         assertThat(attributes.getJSONArray("middleNames").length()).isEqualTo(0);
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smith", true, expectedFromDateString, null, attributes);
-        assertThat(attributes.isNull("dateOfBirth")).isTrue();
+        assertThat(attributes.getJSONArray("datesOfBirth")).isEmpty();
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
     }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -148,8 +148,8 @@ public class NonMatchingAcceptanceTest {
 
         MdsValueChecker.checkMdsValueInArrayAttribute("firstNames", 0, "Bob", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("middleNames", 0, "Montgomery", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smith", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smythington", true, expectedLaterFromDateString, expectedLaterToDateString, attributes);
+        MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smythington", true, expectedLaterFromDateString, expectedLaterToDateString, attributes);
+        MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smith", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("datesOfBirth", 0, "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.client.Entity.json;
@@ -152,8 +153,8 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smith", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("datesOfBirth", 0, "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), "E1 8QX", "", true, expectedLaterFromDateString, null, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), Optional.of("E1 8QS"), Optional.empty(), true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), Optional.of("E1 8QX"), Optional.empty(), true, expectedLaterFromDateString, null, attributes);
     }
 
     @Test
@@ -208,7 +209,7 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smith", true, expectedFromDateString, null, attributes);
         assertThat(attributes.getJSONArray("datesOfBirth")).isEmpty();
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), "E1 8QS", "", true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), Optional.of("E1 8QS"), Optional.empty(), true, expectedFromDateString, expectedToDateString, attributes);
     }
 
     @Test

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
@@ -5,6 +5,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.List;
+import java.util.Optional;
 
 public class MdsValueChecker {
 
@@ -33,8 +34,8 @@ public class MdsValueChecker {
     public static void checkMdsValueOfAddress(
             int index,
             List<String> lines,
-            String postcode,
-            String internationalPostcode,
+            Optional<String> postcode,
+            Optional<String> internationalPostcode,
             boolean expectedIsVerified,
             String expectedFromDateString,
             String expectedToDateString,
@@ -51,8 +52,17 @@ public class MdsValueChecker {
         for (index = 0; index < lines.size(); index++) {
             Assertions.assertThat(jsonLines.getString(index)).isEqualTo(lines.get(index));
         }
-        Assertions.assertThat(addressValue.getString("postCode")).isEqualTo(postcode);
-        Assertions.assertThat(addressValue.getString("internationalPostCode")).isEqualTo(internationalPostcode);
+        if(postcode.isPresent()) {
+            Assertions.assertThat(addressValue.getString("postCode")).isEqualTo(postcode.get());
+        } else {
+
+            Assertions.assertThat(addressValue.has("postCode")).isFalse();
+        }
+        if(internationalPostcode.isPresent()) {
+            Assertions.assertThat(addressValue.getString("internationalPostCode")).isEqualTo(internationalPostcode.get());
+        } else {
+            Assertions.assertThat(addressValue.has("internationalPostCode")).isFalse();
+        }
     }
 
     public static void checkMdsValueInArrayAttribute(

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -14,8 +15,8 @@ public class NonMatchingAddress {
     @JsonCreator
     public NonMatchingAddress(
         @JsonProperty("lines") List<String> lines,
-        @JsonProperty("postCode") String postCode,
-        @JsonProperty("internationalPostCode") String internationalPostCode
+        @JsonProperty("postCode") @JsonInclude(JsonInclude.Include.NON_NULL) String postCode,
+        @JsonProperty("internationalPostCode") @JsonInclude(JsonInclude.Include.NON_NULL) String internationalPostCode
     ) {
         this.lines = lines;
         this.postCode = postCode;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
@@ -10,14 +10,14 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class NonMatchingAttributes {
 
-    @JsonProperty("firstName")
-    private final NonMatchingVerifiableAttribute<String> firstName;
+    @JsonProperty("firstNames")
+    private final List<NonMatchingVerifiableAttribute<String>> firstNames;
     @JsonProperty("middleNames")
     private final List<NonMatchingVerifiableAttribute<String>> middleNames;
     @JsonProperty("surnames")
     private final List<NonMatchingVerifiableAttribute<String>> surnames;
-    @JsonProperty("dateOfBirth")
-    private final NonMatchingVerifiableAttribute<LocalDate> dateOfBirth;
+    @JsonProperty("datesOfBirth")
+    private final List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth;
     @JsonProperty("gender")
     private final NonMatchingVerifiableAttribute<Gender> gender;
     @JsonProperty("addresses")
@@ -25,23 +25,23 @@ public class NonMatchingAttributes {
 
 
     public NonMatchingAttributes(
-            NonMatchingVerifiableAttribute<String> firstName,
+            List<NonMatchingVerifiableAttribute<String>> firstNames,
             List<NonMatchingVerifiableAttribute<String>> middleNames,
             List<NonMatchingVerifiableAttribute<String>> surnames,
-            NonMatchingVerifiableAttribute<LocalDate> dateOfBirth,
+            List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth,
             NonMatchingVerifiableAttribute<Gender> gender,
             List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses
     ) {
-        this.firstName = firstName;
+        this.firstNames = firstNames;
         this.middleNames = middleNames;
         this.surnames = surnames;
-        this.dateOfBirth = dateOfBirth;
+        this.datesOfBirth = datesOfBirth;
         this.gender = gender;
         this.addresses = addresses;
     }
 
-    public NonMatchingVerifiableAttribute<String> getFirstName() {
-        return firstName;
+    public List<NonMatchingVerifiableAttribute<String>> getFirstNames() {
+        return firstNames;
     }
 
     public List<NonMatchingVerifiableAttribute<String>> getMiddleNames() {
@@ -52,8 +52,8 @@ public class NonMatchingAttributes {
         return surnames;
     }
 
-    public NonMatchingVerifiableAttribute<LocalDate> getDateOfBirth() {
-        return dateOfBirth;
+    public List<NonMatchingVerifiableAttribute<LocalDate>> getDatesOfBirth() {
+        return datesOfBirth;
     }
 
     public NonMatchingVerifiableAttribute<Gender> getGender() {
@@ -70,20 +70,20 @@ public class NonMatchingAttributes {
         if (o == null || getClass() != o.getClass()) return false;
 
         NonMatchingAttributes that = (NonMatchingAttributes) o;
-        if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
+        if (firstNames != null ? !firstNames.equals(that.firstNames) : that.firstNames != null) return false;
         if (middleNames != null ? !(that.middleNames != null && CollectionUtils.isEqualCollection(middleNames, that.middleNames)) : that.middleNames != null) return false;
         if (surnames != null ? !(that.surnames != null && CollectionUtils.isEqualCollection(surnames, that.surnames)) : that.surnames != null) return false;
-        if (dateOfBirth != null ? !dateOfBirth.equals(that.dateOfBirth) : that.dateOfBirth != null) return false;
+        if (datesOfBirth != null ? !datesOfBirth.equals(that.datesOfBirth) : that.datesOfBirth != null) return false;
         if (gender != null ? !gender.equals(that.gender) : that.gender != null) return false;
         return (addresses != null ? !(that.addresses != null && CollectionUtils.isEqualCollection(addresses, that.addresses)) : that.addresses != null);
     }
 
     @Override
     public int hashCode() {
-        int result = firstName != null ? firstName.hashCode() : 0;
+        int result = firstNames != null ? firstNames.hashCode() : 0;
         result = 31 * result + (middleNames != null ? middleNames.hashCode() : 0);
         result = 31 * result + (surnames != null ? surnames.hashCode() : 0);
-        result = 31 * result + (dateOfBirth != null ? dateOfBirth.hashCode() : 0);
+        result = 31 * result + (datesOfBirth != null ? datesOfBirth.hashCode() : 0);
         result = 31 * result + (gender != null ? gender.hashCode() : 0);
         result = 31 * result + (addresses != null ? addresses.hashCode() : 0);
         return result;
@@ -92,8 +92,8 @@ public class NonMatchingAttributes {
     @Override
     public String toString() {
         return String.format(
-                "Attributes{ firstName=%s, middleNames=%s, surnames=%s, dateOfBirth=%s, gender=%s, addresses=%s}",
-                firstName, middleNames, surnames, dateOfBirth, gender, addresses);
+                "Attributes{ firstNames=%s, middleNames=%s, surnames=%s, datesOfBirth=%s, gender=%s, addresses=%s}",
+                firstNames, middleNames, surnames, datesOfBirth, gender, addresses);
     }
 
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -86,8 +86,8 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
         return addresses.stream().map((input) -> {
             NonMatchingAddress transformedAddress = new NonMatchingAddress(
                 input.getLines(),
-                input.getPostCode().orElse(""),
-                input.getInternationalPostCode().orElse("")
+                input.getPostCode().orElse(null),
+                input.getInternationalPostCode().orElse(null)
             );
 
             LocalDateTime from = Optional.ofNullable(input.getFrom())

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -4,10 +4,10 @@ import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
-import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAddress;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,23 +17,29 @@ import java.util.stream.Collectors;
 public class MatchingDatasetToNonMatchingAttributesMapper {
 
     public NonMatchingAttributes mapToNonMatchingAttributes(MatchingDataset matchingDataset) {
-        Optional<TransliterableMdsValue> firstNameValue = matchingDataset.getFirstNames().stream().findFirst();
-        Optional<SimpleMdsValue<LocalDate>> birthDateValue = matchingDataset.getDateOfBirths().stream()
+        List<NonMatchingVerifiableAttribute<String>> firstNames = matchingDataset.getFirstNames().stream()
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .collect(Collectors.toList());
+        List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth = matchingDataset.getDateOfBirths().stream()
             .map(MatchingDatasetToNonMatchingAttributesMapper::convertWrappedJodaLocalDateToJavaLocalDate)
-            .findFirst();
-
-        NonMatchingVerifiableAttribute<String> firstName = firstNameValue.map(this::mapToNonMatchingVerifiableAttribute).orElse(null);
-        List<NonMatchingVerifiableAttribute<String>> middleNames = matchingDataset.getMiddleNames().stream().map(this::mapToNonMatchingVerifiableAttribute).collect(Collectors.toList());
-        List<NonMatchingVerifiableAttribute<String>> surnames = matchingDataset.getSurnames().stream().map(this::mapToNonMatchingVerifiableAttribute).collect(Collectors.toList());
-        NonMatchingVerifiableAttribute<LocalDate> dateOfBirth = birthDateValue.map(this::mapToNonMatchingVerifiableAttribute).orElse(null);
-        NonMatchingVerifiableAttribute<Gender> gender = matchingDataset.getGender().map(this::mapToNonMatchingVerifiableAttribute).orElse(null);
+            .map(this::mapToNonMatchingVerifiableAttribute)
+            .collect(Collectors.toList());
+        List<NonMatchingVerifiableAttribute<String>> middleNames = matchingDataset.getMiddleNames()
+                .stream().map(this::mapToNonMatchingVerifiableAttribute)
+                .collect(Collectors.toList());
+        List<NonMatchingVerifiableAttribute<String>> surnames = matchingDataset.getSurnames().stream()
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .collect(Collectors.toList());
+        NonMatchingVerifiableAttribute<Gender> gender = matchingDataset.getGender()
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .orElse(null);
         List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses = mapAddresses(matchingDataset.getAddresses());
 
         return new NonMatchingAttributes(
-            firstName,
+            firstNames,
             middleNames,
             surnames,
-            dateOfBirth,
+            datesOfBirth,
             gender,
             addresses
         );

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -41,7 +41,7 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
     private List<NonMatchingVerifiableAttribute<String>> convertNameAttributes(List<SimpleMdsValue<String>> values) {
         return values.stream()
                 .map(this::mapToNonMatchingVerifiableAttribute)
-                .sorted(fromDateComparator())
+                .sorted(attributeComparator())
                 .collect(Collectors.toList());
     }
 
@@ -49,20 +49,22 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
         return values.stream()
                 .map(MatchingDatasetToNonMatchingAttributesMapper::convertWrappedJodaLocalDateToJavaLocalDate)
                 .map(this::mapToNonMatchingVerifiableAttribute)
-                .sorted(fromDateComparator())
+                .sorted(attributeComparator())
                 .collect(Collectors.toList());
     }
 
     private List<NonMatchingVerifiableAttribute<String>> convertTransliterableNameAttributes(List<TransliterableMdsValue> values) {
         return values.stream()
                 .map(this::mapToNonMatchingVerifiableAttribute)
-                .sorted(fromDateComparator())
+                .sorted(attributeComparator())
                 .collect(Collectors.toList());
     }
 
 
-    private <T> Comparator<NonMatchingVerifiableAttribute<T>> fromDateComparator() {
-        return Comparator.comparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
+    public static <T> Comparator<NonMatchingVerifiableAttribute<T>> attributeComparator() {
+        return Comparator.<NonMatchingVerifiableAttribute<T>, LocalDateTime>comparing(NonMatchingVerifiableAttribute::getTo, Comparator.nullsFirst(Comparator.reverseOrder()))
+                .thenComparing(NonMatchingVerifiableAttribute::isVerified, Comparator.reverseOrder())
+                .thenComparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
     }
 
     private <T> NonMatchingVerifiableAttribute<T> mapToNonMatchingVerifiableAttribute(SimpleMdsValue<T> simpleMdsValueOptional) {
@@ -104,7 +106,7 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
                 from,
                 to
             );
-        }).sorted(fromDateComparator()).collect(Collectors.toList());
+        }).sorted(attributeComparator()).collect(Collectors.toList());
     }
 
     private static LocalDateTime convertJodaDateTimeToJavaLocalDateTime(org.joda.time.DateTime jodaDateTime) {

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import java.time.LocalDateTime;
+
+public class NonMatchingVerifiableAttributeBuilder {
+    private String value = "VALUE";
+    private boolean verified = true;
+    private LocalDateTime from = LocalDateTime.now();
+    private LocalDateTime to = null;
+
+    public NonMatchingVerifiableAttributeBuilder withVerified(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttributeBuilder withFrom(LocalDateTime from) {
+        this.from = from;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttributeBuilder withTo(LocalDateTime to) {
+        this.to = to;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttribute<String> build() {
+        return new NonMatchingVerifiableAttribute<>(value, verified, from, to);
+    }
+}

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
@@ -1,0 +1,283 @@
+package uk.gov.ida.verifyserviceprovider.mappers;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAddress;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MatchingDatasetToNonMatchingAttributesMapperTest {
+
+    private final DateTime fromTwo = DateTime.now().minusDays(30);
+    private final DateTime fromOne = DateTime.now();
+    private final DateTime fromThree = DateTime.now().minusDays(6);
+    private final DateTime fromFour = null;
+    private final String foo = "Foo";
+    private final String bar = "Bar";
+    private final String baz = "Baz";
+    private final String fuu = "Fuu";
+
+    @Test
+    public void shouldMapFirstNames() {
+        List<TransliterableMdsValue> firstNames = asList(
+                createTransliterableValue(fromThree, foo),
+                createTransliterableValue(fromTwo, bar),
+                createTransliterableValue(fromOne, baz),
+                createTransliterableValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                firstNames,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getFirstNames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getFirstNames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapMiddlenames() {
+        List<SimpleMdsValue<String>> middleNames = asList(
+                createSimpleMdsValue(fromThree, foo),
+                createSimpleMdsValue(fromTwo, bar),
+                createSimpleMdsValue(fromOne, baz),
+                createSimpleMdsValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                middleNames,
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getMiddleNames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getFirstNames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapSurnames() {
+        List<TransliterableMdsValue> surnames = asList(
+                createTransliterableValue(fromThree, foo),
+                createTransliterableValue(fromTwo, bar),
+                createTransliterableValue(fromOne, baz),
+                createTransliterableValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                surnames,
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getSurnames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getSurnames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapDatesOfBirth() {
+        LocalDate fooDate = LocalDate.now();
+        LocalDate barDate = LocalDate.now().minusDays(5);
+        LocalDate bazDate = LocalDate.now().minusDays(10);
+        LocalDate fuuDate = LocalDate.now().minusDays(15);
+        List<SimpleMdsValue<LocalDate>> datesOfBirth = asList(
+                createDateValue(fromThree, fooDate),
+                createDateValue(fromTwo, barDate),
+                createDateValue(fromOne, bazDate),
+                createDateValue(fromFour, fuuDate)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                datesOfBirth,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        List<String> expectedDates = Stream.of(bazDate, fooDate, barDate, fuuDate)
+                .map(LocalDate::toString)
+                .collect(Collectors.toList());
+        assertThat(nonMatchingAttributes.getDatesOfBirth().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(java.time.LocalDate::toString)
+                .collect(Collectors.toList()))
+                .isEqualTo(expectedDates);
+        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapCurrentAddress() {
+        List<Address> currentAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromTwo, bar),
+                createAddress(fromOne, baz),
+                createAddress(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                currentAddress,
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapPreviousAddress() {
+        List<Address> previousAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromTwo, bar),
+                createAddress(fromOne, baz),
+                createAddress(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                previousAddress,
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapAndMergeAddress() {
+        List<Address> previousAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromFour, fuu)
+        );
+        List<Address> currentAddress = asList(
+                createAddress(fromOne, baz),
+                createAddress(fromTwo, bar)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                currentAddress,
+                previousAddress,
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapGender() {
+        Gender gender = Gender.NOT_SPECIFIED;
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.of(new SimpleMdsValue<>(gender, null, null, true)),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getGender().getValue()).isEqualTo(gender);
+    }
+
+    private Comparator<NonMatchingVerifiableAttribute<?>> comparedByFromDate() {
+        return Comparator.comparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
+    }
+
+    private Address createAddress(DateTime from, String postCode) {
+        return new Address(Collections.emptyList(), postCode, null, null, from, null, true);
+    }
+
+    private TransliterableMdsValue createTransliterableValue(DateTime from, String value) {
+        return new TransliterableMdsValue(createSimpleMdsValue(from, value));
+    }
+
+    private SimpleMdsValue<String> createSimpleMdsValue(DateTime from, String value) {
+        return new SimpleMdsValue<>(value, from, null, true);
+    }
+
+    private SimpleMdsValue<LocalDate> createDateValue(DateTime from, LocalDate dateTime) {
+        return new SimpleMdsValue<>(dateTime, from, null, true);
+    }
+}


### PR DESCRIPTION
The SAML profile specified that attribtue should be provided as a list with historical context, but we were ignoring this and only returning the first of some attributes (firstName, and Date Of Birth). In some case this could cause problems if a non-verified attribute was returned when a verified attribute was available.

This PR changes the attributes returned to make them more consistent with the SAML profile.
The following attributes will now be provided with possible historical values:
- firstNames
- middleNames
- surnames
- dates Of Birth
- addresses

Gender will still be provided as a single attribute.

