### PR TITLE
Allow external binaries in docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ data/**
 /.mongo/*
 !/.mongo/.gitkeep
 node_modules
+.classpath
+.project
+.settings
+bin

--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -1,4 +1,5 @@
 FROM gradle:5.1-jdk8 as build
+ARG VERIFY_USE_PUBLIC_BINARIES=false
 WORKDIR /verify-service-provider
 USER root
 ENV GRADLE_USER_HOME ~/.gradle


### PR DESCRIPTION
In some circumstances the artifactory repo isn't available (proxy-node) and so we need the option to fall back to the public ones.

Solo: @blairboy362 