### PR TITLE
OLqSibaL: Add UPRN to Addresses returned by the VSP

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.verifyserviceprovider.Utils.MdsValueChecker;
 import uk.gov.ida.verifyserviceprovider.compliance.ComplianceToolMode;
-import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAddress;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAttribute;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDataset;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDatasetBuilder;
@@ -299,15 +298,7 @@ public class ComplianceToolModeAcceptanceTest {
         checkMatchingDatasetListAttribute(attributes, "surnames", 1, sortedSurnames);
         checkMatchingDatasetListAttribute(attributes, "datesOfBirth", 0, matchingDataset.getDateOfBirth());
         checkMatchingDatasetAttribute(attributes, "gender", matchingDataset.getGender());
-        checkMatchingDatasetAddress(attributes, 0, matchingDataset.getAddresses());
-    }
-
-    private void checkMatchingDatasetAddress(JSONObject attributes, int index, List<MatchingAddress> addresses) {
-        MatchingAddress address = addresses.get(index);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String fromDate = address.getFrom().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String toDate = address.getTo().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        MdsValueChecker.checkMdsValueOfAddress(index, address.getLines(), address.getPostCode(), address.getInternationalPostCode(), address.isVerified(), fromDate, toDate, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, attributes, matchingDataset.getAddresses().get(0));
     }
 
     private void checkMatchingDatasetListAttribute(JSONObject attributes, String attributeName, int index, MatchingAttribute expectedAttribute) {

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -25,7 +25,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.client.Entity.json;
@@ -109,16 +108,29 @@ public class NonMatchingAcceptanceTest {
         LocalDateTime laterFromDate = LocalDateTime.parse(laterFromDateString);
         LocalDateTime laterToDate = LocalDateTime.parse(laterToDateString);
 
+        MatchingAddress matchingAddressOne = new MatchingAddress(true,
+                standardFromDate,
+                standardToDate,
+                "E1 8QS",
+                Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"),
+                "INT123",
+                "UPRN");
+        MatchingAddress matchingAddressTwo = new MatchingAddress(true,
+                laterFromDate,
+                null,
+                "E1 8QX",
+                Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"),
+                null,
+                null);
         MatchingDataset matchingDataset = new MatchingDataset(
             new MatchingAttribute("Bob", true, standardFromDate, standardToDate),
             new MatchingAttribute("Montgomery", true, standardFromDate, standardToDate),
-            Arrays.asList(new MatchingAttribute("Smith", true, standardFromDate, standardToDate), new MatchingAttribute("Smythington", true, laterFromDate, laterToDate)),
+            Arrays.asList(new MatchingAttribute("Smith", true, standardFromDate, standardToDate),
+                    new MatchingAttribute("Smythington", true, laterFromDate, laterToDate)
+            ),
             new MatchingAttribute("NOT_SPECIFIED", true, standardFromDate, standardToDate),
             new MatchingAttribute("1970-01-01", true, standardFromDate, standardToDate),
-            Arrays.asList(
-                    new MatchingAddress(true, standardFromDate, standardToDate, "E1 8QS", Arrays.asList("The White Chapel Building" ,"10 Whitechapel High Street"), null, null),
-                    new MatchingAddress(true, laterFromDate, null, "E1 8QX", Arrays.asList("The White Chapel Building 2" ,"11 Whitechapel High Street"), null, null)
-            ),
+            Arrays.asList( matchingAddressOne, matchingAddressTwo),
             AuthnContext.LEVEL_1,
             expectedPid
         );
@@ -155,8 +167,8 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 1, "Smith", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("datesOfBirth", 0, "1970-01-01", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(1, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), Optional.of("E1 8QS"), Optional.empty(), true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building 2", "11 Whitechapel High Street"), Optional.of("E1 8QX"), Optional.empty(), true, expectedLaterFromDateString, null, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, attributes, matchingAddressTwo);
+        MdsValueChecker.checkMdsValueOfAddress(1, attributes, matchingAddressOne);
     }
 
     @Test
@@ -169,13 +181,22 @@ public class NonMatchingAcceptanceTest {
         LocalDateTime standardToDate = LocalDateTime.parse(standardToDateString);
 
 
+        MatchingAddress matchingAddress = new MatchingAddress(
+                true,
+                standardFromDate,
+                standardToDate,
+                "E1 8QS",
+                Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"),
+                null,
+                null
+        );
         MatchingDataset matchingDataset = new MatchingDataset(
                 new MatchingAttribute("Bob", true, standardFromDate, standardToDate),
                 null,
                 singletonList(new MatchingAttribute("Smith", true, standardFromDate, null)),
                 new MatchingAttribute("NOT_SPECIFIED", true, standardFromDate, standardToDate),
                 null,
-                singletonList(new MatchingAddress(true, standardFromDate, standardToDate, "E1 8QS", Arrays.asList("The White Chapel Building" ,"10 Whitechapel High Street"), null, null)),
+                singletonList(matchingAddress),
                 AuthnContext.LEVEL_1,
                 expectedPid
         );
@@ -212,7 +233,7 @@ public class NonMatchingAcceptanceTest {
         MdsValueChecker.checkMdsValueInArrayAttribute("surnames", 0, "Smith", true, expectedFromDateString, null, attributes);
         assertThat(attributes.getJSONArray("datesOfBirth")).isEmpty();
         MdsValueChecker.checkMdsValueOfAttribute("gender", "NOT_SPECIFIED", true, expectedFromDateString, expectedToDateString, attributes);
-        MdsValueChecker.checkMdsValueOfAddress(0, Arrays.asList("The White Chapel Building", "10 Whitechapel High Street"), Optional.of("E1 8QS"), Optional.empty(), true, expectedFromDateString, expectedToDateString, attributes);
+        MdsValueChecker.checkMdsValueOfAddress(0, attributes, matchingAddress);
     }
 
     @Test

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
@@ -59,6 +59,7 @@ public class NonMatchingAddress {
         int result = lines != null ? lines.hashCode() : 0;
         result = 31 * result + (postCode != null ? postCode.hashCode() : 0);
         result = 31 * result + (internationalPostCode != null ? internationalPostCode.hashCode() : 0);
+        result = 31 * result + (uprn != null ? uprn.hashCode() : 0);
         return result;
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
@@ -7,20 +7,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class NonMatchingAddress {
-
     private final List<String> lines;
     private final String postCode;
     private final String internationalPostCode;
+    private final String uprn;
 
     @JsonCreator
     public NonMatchingAddress(
         @JsonProperty("lines") List<String> lines,
         @JsonProperty("postCode") @JsonInclude(JsonInclude.Include.NON_NULL) String postCode,
-        @JsonProperty("internationalPostCode") @JsonInclude(JsonInclude.Include.NON_NULL) String internationalPostCode
+        @JsonProperty("internationalPostCode") @JsonInclude(JsonInclude.Include.NON_NULL) String internationalPostCode,
+        @JsonProperty("uprn") @JsonInclude(JsonInclude.Include.NON_NULL) String uprn
     ) {
         this.lines = lines;
         this.postCode = postCode;
         this.internationalPostCode = internationalPostCode;
+        this.uprn = uprn;
     }
 
     public List<String> getLines() {
@@ -35,6 +37,10 @@ public class NonMatchingAddress {
         return internationalPostCode;
     }
 
+    public String getUprn() {
+        return uprn;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -44,6 +50,7 @@ public class NonMatchingAddress {
 
         if (lines != null ? !lines.equals(other.lines) : other.lines != null) return false;
         if (postCode != null ? !postCode.equals(other.postCode) : other.postCode != null) return false;
+        if (uprn != null ? !uprn.equals(other.uprn) : other.uprn != null) return false;
         return (internationalPostCode != null ? !internationalPostCode.equals(other.internationalPostCode) : other.internationalPostCode != null);
     }
 
@@ -61,6 +68,7 @@ public class NonMatchingAddress {
             ", lines=" + lines +
             ", postCode='" + postCode + '\'' +
             ", internationalPostCode='" + internationalPostCode + '\'' +
+            ", uprn='" + uprn + '\'' +
             '}';
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -85,28 +85,31 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
     }
 
     private List<NonMatchingVerifiableAttribute<NonMatchingAddress>> mapAddresses(List<Address> addresses) {
-        return addresses.stream().map((input) -> {
-            NonMatchingAddress transformedAddress = new NonMatchingAddress(
-                input.getLines(),
-                input.getPostCode().orElse(null),
-                input.getInternationalPostCode().orElse(null)
-            );
+        return addresses.stream().map(this::mapAddress).sorted(attributeComparator()).collect(Collectors.toList());
+    }
 
-            LocalDateTime from = Optional.ofNullable(input.getFrom())
-                    .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
-                    .orElse(null);
+    private NonMatchingVerifiableAttribute<NonMatchingAddress> mapAddress(Address input) {
+        NonMatchingAddress transformedAddress = new NonMatchingAddress(
+            input.getLines(),
+            input.getPostCode().orElse(null),
+            input.getInternationalPostCode().orElse(null),
+            input.getUPRN().orElse(null)
+        );
 
-            LocalDateTime to = input.getTo()
-                    .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
-                    .orElse(null);
+        LocalDateTime from = Optional.ofNullable(input.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+                .orElse(null);
 
-            return new NonMatchingVerifiableAttribute<>(
-                transformedAddress,
-                input.isVerified(),
-                from,
-                to
-            );
-        }).sorted(attributeComparator()).collect(Collectors.toList());
+        LocalDateTime to = input.getTo()
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+                .orElse(null);
+
+        return new NonMatchingVerifiableAttribute<>(
+            transformedAddress,
+            input.isVerified(),
+            from,
+            to
+        );
     }
 
     private static LocalDateTime convertJodaDateTimeToJavaLocalDateTime(org.joda.time.DateTime jodaDateTime) {

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
@@ -90,7 +90,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
                 .map(NonMatchingVerifiableAttribute::getValue)
                 .collect(Collectors.toList()))
                 .isEqualTo(asList(baz, foo, bar, fuu));
-        assertThat(nonMatchingAttributes.getFirstNames()).isSortedAccordingTo(comparedByFromDate());
+        assertThat(nonMatchingAttributes.getMiddleNames()).isSortedAccordingTo(comparedByFromDate());
     }
 
     @Test
@@ -158,6 +158,31 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
     }
 
     @Test
+    public void shouldMapAddressesAndNotDiscardAttributes() {
+        Address addressIn = createAddress(fromOne, baz);
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.singletonList(addressIn),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingAddress addressOut = nonMatchingAttributes.getAddresses().get(0).getValue();
+        assertThat(addressOut.getPostCode()).isEqualTo(addressIn.getPostCode().get());
+        assertThat(addressOut.getInternationalPostCode()).isEqualTo(addressIn.getInternationalPostCode().get());
+        assertThat(addressOut.getUprn()).isEqualTo(addressIn.getUPRN().get());
+        assertThat(addressOut.getLines()).isEqualTo(addressIn.getLines());
+
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
     public void shouldMapCurrentAddress() {
         List<Address> currentAddress = asList(
                 createAddress(fromThree, foo),
@@ -183,7 +208,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
                 .map(NonMatchingAddress::getPostCode)
                 .collect(Collectors.toList()))
                 .isEqualTo(asList(baz, foo, bar, fuu));
-        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
     }
 
     @Test
@@ -212,7 +237,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
                 .map(NonMatchingAddress::getPostCode)
                 .collect(Collectors.toList()))
                 .isEqualTo(asList(baz, foo, bar, fuu));
-        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
     }
 
     @Test
@@ -243,7 +268,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
                 .map(NonMatchingAddress::getPostCode)
                 .collect(Collectors.toList()))
                 .isEqualTo(asList(baz, foo, bar, fuu));
-        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
     }
 
     @Test
@@ -306,7 +331,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
     }
 
     private Address createAddress(DateTime from, String postCode) {
-        return new Address(Collections.emptyList(), postCode, null, null, from, null, true);
+        return new Address(Collections.emptyList(), postCode, "BAR", "BAZ", from, null, true);
     }
 
     private TransliterableMdsValue createTransliterableValue(DateTime from, String value) {


### PR DESCRIPTION
# What
Addresses from our IDPs may include a UPRN field, but the VSP is currently ignoring it in our response back to the service. We should include it as it may be helpful to a service.

# Why
The UPRN could be used by a service to assist with matching or other reasons.