### PR TITLE
gUPcguib: Use LocalDate instead of LocalDateTime

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -302,9 +302,9 @@ public class ComplianceToolModeAcceptanceTest {
     }
 
     private void checkMatchingDatasetListAttribute(JSONObject attributes, String attributeName, int index, MatchingAttribute expectedAttribute) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String fromDate = expectedAttribute.getFrom().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String toDate = expectedAttribute.getTo().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String fromDate = expectedAttribute.getFrom().toLocalDate().atStartOfDay().format(formatter);
+        String toDate = expectedAttribute.getTo().toLocalDate().atStartOfDay().format(formatter);
         MdsValueChecker.checkMdsValueInArrayAttribute(attributeName, index, expectedAttribute.getValue(), expectedAttribute.isVerified(), fromDate, toDate, attributes);
     }
 
@@ -314,9 +314,9 @@ public class ComplianceToolModeAcceptanceTest {
     }
 
     private void checkMatchingDatasetAttribute(JSONObject attributes, String attributeName, MatchingAttribute expectedAttribute) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String fromDate = expectedAttribute.getFrom().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String toDate = expectedAttribute.getTo().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String fromDate = expectedAttribute.getFrom().toLocalDate().atStartOfDay().format(formatter);
+        String toDate = expectedAttribute.getTo().toLocalDate().atStartOfDay().format(formatter);
         MdsValueChecker.checkMdsValueOfAttribute(attributeName, expectedAttribute.getValue(), expectedAttribute.isVerified(), fromDate, toDate, attributes);
     }
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -155,11 +155,11 @@ public class NonMatchingAcceptanceTest {
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
         assertThat(attributes.keys()).containsExactlyInAnyOrder(COMMON_ATTRIBUTES);
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String expectedToDateString = standardToDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String expectedLaterFromDateString = laterFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String expectedLaterToDateString = laterToDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter);
+        String expectedToDateString = standardToDate.toLocalDate().atStartOfDay().format(formatter);
+        String expectedLaterFromDateString = laterFromDate.toLocalDate().atStartOfDay().format(formatter);
+        String expectedLaterToDateString = laterToDate.toLocalDate().atStartOfDay().format(formatter);
 
         MdsValueChecker.checkMdsValueInArrayAttribute("firstNames", 0, "Bob", true, expectedFromDateString, expectedToDateString, attributes);
         MdsValueChecker.checkMdsValueInArrayAttribute("middleNames", 0, "Montgomery", true, expectedFromDateString, expectedToDateString, attributes);
@@ -224,9 +224,9 @@ public class NonMatchingAcceptanceTest {
 
         JSONObject attributes = jsonResponse.getJSONObject("attributes");
         assertThat(attributes.keys()).containsExactlyInAnyOrder(COMMON_ATTRIBUTES);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
-        String expectedToDateString = standardToDate.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String expectedFromDateString = standardFromDate.toLocalDate().atStartOfDay().format(formatter);
+        String expectedToDateString = standardToDate.toLocalDate().atStartOfDay().format(formatter);
 
         MdsValueChecker.checkMdsValueInArrayAttribute("firstNames", 0, "Bob", true, expectedFromDateString, expectedToDateString, attributes);
         assertThat(attributes.getJSONArray("middleNames").length()).isEqualTo(0);

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/Utils/MdsValueChecker.java
@@ -38,10 +38,10 @@ public class MdsValueChecker {
             JSONObject attributes,
             MatchingAddress matchingAddress
     ) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String fromDate = matchingAddress.getFrom().toLocalDate().atStartOfDay().format(formatter).replace(" ", "T");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String fromDate = matchingAddress.getFrom().toLocalDate().atStartOfDay().format(formatter);
         String toDate = Optional.ofNullable(matchingAddress.getTo())
-                .map((dt) -> dt.toLocalDate().atStartOfDay().format(formatter).replace(" ", "T"))
+                .map((dt) -> dt.toLocalDate().atStartOfDay().format(formatter))
                 .orElse(null);
         checkMdsValueOfAddress(
                 index,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
@@ -2,7 +2,8 @@ package uk.gov.ida.verifyserviceprovider.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 
 public class NonMatchingVerifiableAttribute<T> {
 
@@ -11,15 +12,15 @@ public class NonMatchingVerifiableAttribute<T> {
     @JsonProperty("verified")
     private final boolean verified;
     @JsonProperty("from") @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final LocalDateTime from;
+    private final LocalDate from;
     @JsonProperty("to") @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final LocalDateTime to;
+    private final LocalDate to;
 
     public NonMatchingVerifiableAttribute(
            T value,
            boolean verified,
-           LocalDateTime from,
-           LocalDateTime to) {
+           LocalDate from,
+           LocalDate to) {
         this.value = value;
         this.verified = verified;
         this.from = from;
@@ -34,9 +35,9 @@ public class NonMatchingVerifiableAttribute<T> {
         return verified;
     }
 
-    public LocalDateTime getFrom() { return from; }
+    public LocalDate getFrom() { return from; }
 
-    public LocalDateTime getTo() { return to; }
+    public LocalDate getTo() { return to; }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -62,18 +62,18 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
 
 
     public static <T> Comparator<NonMatchingVerifiableAttribute<T>> attributeComparator() {
-        return Comparator.<NonMatchingVerifiableAttribute<T>, LocalDateTime>comparing(NonMatchingVerifiableAttribute::getTo, Comparator.nullsFirst(Comparator.reverseOrder()))
+        return Comparator.<NonMatchingVerifiableAttribute<T>, LocalDate>comparing(NonMatchingVerifiableAttribute::getTo, Comparator.nullsFirst(Comparator.reverseOrder()))
                 .thenComparing(NonMatchingVerifiableAttribute::isVerified, Comparator.reverseOrder())
                 .thenComparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
     }
 
     private <T> NonMatchingVerifiableAttribute<T> mapToNonMatchingVerifiableAttribute(SimpleMdsValue<T> simpleMdsValueOptional) {
-        LocalDateTime from = Optional.ofNullable(simpleMdsValueOptional.getFrom())
-                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+        LocalDate from = Optional.ofNullable(simpleMdsValueOptional.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
                 .orElse(null);
 
-        LocalDateTime to = Optional.ofNullable(simpleMdsValueOptional.getTo())
-                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+        LocalDate to = Optional.ofNullable(simpleMdsValueOptional.getTo())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
                 .orElse(null);
 
         return new NonMatchingVerifiableAttribute<>(
@@ -96,12 +96,12 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
             input.getUPRN().orElse(null)
         );
 
-        LocalDateTime from = Optional.ofNullable(input.getFrom())
-                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+        LocalDate from = Optional.ofNullable(input.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
                 .orElse(null);
 
-        LocalDateTime to = input.getTo()
-                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDateTime)
+        LocalDate to = input.getTo()
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
                 .orElse(null);
 
         return new NonMatchingVerifiableAttribute<>(
@@ -112,15 +112,11 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
         );
     }
 
-    private static LocalDateTime convertJodaDateTimeToJavaLocalDateTime(org.joda.time.DateTime jodaDateTime) {
-        return LocalDateTime.of(
+    private static LocalDate convertJodaDateTimeToJavaLocalDate(org.joda.time.DateTime jodaDateTime) {
+        return LocalDate.of(
             jodaDateTime.getYear(),
             jodaDateTime.getMonthOfYear(),
-            jodaDateTime.getDayOfMonth(),
-            jodaDateTime.getHourOfDay(),
-            jodaDateTime.getMinuteOfHour(),
-            jodaDateTime.getSecondOfMinute(),
-            jodaDateTime.getMillisOfSecond()
+            jodaDateTime.getDayOfMonth()
         );
     }
 

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
@@ -1,24 +1,24 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class NonMatchingVerifiableAttributeBuilder {
     private String value = "VALUE";
     private boolean verified = true;
-    private LocalDateTime from = LocalDateTime.now();
-    private LocalDateTime to = null;
+    private LocalDate from = LocalDate.now();
+    private LocalDate to = null;
 
     public NonMatchingVerifiableAttributeBuilder withVerified(boolean verified) {
         this.verified = verified;
         return this;
     }
 
-    public NonMatchingVerifiableAttributeBuilder withFrom(LocalDateTime from) {
+    public NonMatchingVerifiableAttributeBuilder withFrom(LocalDate from) {
         this.from = from;
         return this;
     }
 
-    public NonMatchingVerifiableAttributeBuilder withTo(LocalDateTime to) {
+    public NonMatchingVerifiableAttributeBuilder withTo(LocalDate to) {
         this.to = to;
         return this;
     }

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.verifyserviceprovider.mappers;
 
 import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.junit.Test;
 import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.Gender;
@@ -13,7 +12,7 @@ import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttributeBuilder;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -27,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MatchingDatasetToNonMatchingAttributesMapperTest {
 
-    private final DateTime fromTwo = DateTime.now().minusDays(30);
-    private final DateTime fromOne = DateTime.now();
-    private final DateTime fromThree = DateTime.now().minusDays(6);
-    private final DateTime fromFour = null;
+    private final org.joda.time.DateTime fromTwo = org.joda.time.DateTime.now().minusDays(30);
+    private final org.joda.time.DateTime fromOne = org.joda.time.DateTime.now();
+    private final org.joda.time.DateTime fromThree = org.joda.time.DateTime.now().minusDays(6);
+    private final org.joda.time.DateTime fromFour = null;
 
     private final String foo = "Foo";
     private final String bar = "Bar";
@@ -123,11 +122,11 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
 
     @Test
     public void shouldMapDatesOfBirth() {
-        LocalDate fooDate = LocalDate.now();
-        LocalDate barDate = LocalDate.now().minusDays(5);
-        LocalDate bazDate = LocalDate.now().minusDays(10);
-        LocalDate fuuDate = LocalDate.now().minusDays(15);
-        List<SimpleMdsValue<LocalDate>> datesOfBirth = asList(
+        org.joda.time.LocalDate fooDate = org.joda.time.LocalDate.now();
+        org.joda.time.LocalDate barDate = org.joda.time.LocalDate.now().minusDays(5);
+        org.joda.time.LocalDate bazDate = org.joda.time.LocalDate.now().minusDays(10);
+        org.joda.time.LocalDate fuuDate = org.joda.time.LocalDate.now().minusDays(15);
+        List<SimpleMdsValue<org.joda.time.LocalDate>> datesOfBirth = asList(
                 createDateValue(fromThree, fooDate),
                 createDateValue(fromTwo, barDate),
                 createDateValue(fromOne, bazDate),
@@ -147,7 +146,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
         NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
 
         List<String> expectedDates = Stream.of(bazDate, fooDate, barDate, fuuDate)
-                .map(LocalDate::toString)
+                .map(org.joda.time.LocalDate::toString)
                 .collect(Collectors.toList());
         assertThat(nonMatchingAttributes.getDatesOfBirth().stream()
                 .map(NonMatchingVerifiableAttribute::getValue)
@@ -291,9 +290,9 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
 
     @Test
     public void sortTheListByToDateThenIsVerifiedThenFromDate() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime fiveDaysAgo = now.minusDays(5);
-        LocalDateTime threeDaysAgo = now.minusDays(3);
+        LocalDate now = LocalDate.now();
+        LocalDate fiveDaysAgo = now.minusDays(5);
+        LocalDate threeDaysAgo = now.minusDays(3);
         NonMatchingVerifiableAttribute<String> attributeOne = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(null).withFrom(now).build();
         NonMatchingVerifiableAttribute<String> attributeTwo = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(null).withFrom(fiveDaysAgo).build();
         NonMatchingVerifiableAttribute<String> attributeThree = new NonMatchingVerifiableAttributeBuilder().withVerified(false).withTo(null).withFrom(now).build();
@@ -342,7 +341,7 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
         return new SimpleMdsValue<>(value, from, null, true);
     }
 
-    private SimpleMdsValue<LocalDate> createDateValue(DateTime from, LocalDate dateTime) {
+    private SimpleMdsValue<org.joda.time.LocalDate> createDateValue(org.joda.time.DateTime from, org.joda.time.LocalDate dateTime) {
         return new SimpleMdsValue<>(dateTime, from, null, true);
     }
 }


### PR DESCRIPTION
The from/to dates in NonMatchingVerifiableAttribute should be LocalDates, not LocalDateTimes.  The time component is not useful.