### PR TITLE
9ZNOyJJW: include nonLatinScriptValue on name attributes

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
@@ -50,9 +50,6 @@ public class NonMatchingEidasAcceptanceTest {
         openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
     }
 
-    @Before
-
-
     @Test
      public void shouldReturn400WhenAssertionContainsInvalidSignature() throws MarshallingException, SignatureException {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
@@ -1,10 +1,25 @@
 package uk.gov.ida.verifyserviceprovider;
 
 import org.apache.http.HttpStatus;
+import org.joda.time.LocalDate;
+import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
+import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
+import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentFamilyNameBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentGivenNameBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.DateOfBirthBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.PersonIdentifierBuilder;
+import uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder;
 import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.verifyserviceprovider.dto.TranslateSamlResponseBody;
 import uk.gov.ida.verifyserviceprovider.rules.NonMatchingVerifyServiceProviderAppRule;
@@ -28,7 +43,17 @@ public class NonMatchingEidasAcceptanceTest {
     @ClassRule
     public static NonMatchingVerifyServiceProviderAppRule appWithEidasDisabled = new NonMatchingVerifyServiceProviderAppRule(false);
 
-     @Test
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    }
+
+    @Before
+
+
+    @Test
      public void shouldReturn400WhenAssertionContainsInvalidSignature() throws MarshallingException, SignatureException {
          String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(
                  anInvalidAssertionSignatureEidasResponse("requestId", appWithEidasEnabled.getCountryEntityId()).build()
@@ -90,5 +115,74 @@ public class NonMatchingEidasAcceptanceTest {
 
          assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
      }
+
+    @Test
+    public void shouldMapAttributesCorrectly() throws Exception {
+        AttributeStatementBuilder attributeStatementBuilder = AttributeStatementBuilder.anAttributeStatement();
+        
+        Attribute firstName =  anAttribute(IdaConstants.Eidas_Attributes.FirstName.NAME);
+        CurrentGivenName firstNameValue = new CurrentGivenNameBuilder().buildObject();
+        firstNameValue.setFirstName("Joe");
+        firstName.getAttributeValues().add(firstNameValue);
+        CurrentGivenName nonLatinScriptFirstNameValue = new CurrentGivenNameBuilder().buildObject();
+        nonLatinScriptFirstNameValue.setFirstName("NonLatinJoe");
+        nonLatinScriptFirstNameValue.setIsLatinScript(false);
+        firstName.getAttributeValues().add(nonLatinScriptFirstNameValue);
+
+        attributeStatementBuilder.addAttribute(firstName);
+
+        Attribute familyName =  anAttribute(IdaConstants.Eidas_Attributes.FamilyName.NAME);
+
+        CurrentFamilyName familyNameValue = new CurrentFamilyNameBuilder().buildObject();
+        familyNameValue.setFamilyName("Bloggs");
+        familyName.getAttributeValues().add(familyNameValue);
+
+        CurrentFamilyName nonLatinFamilyNameValue = new CurrentFamilyNameBuilder().buildObject();
+        nonLatinFamilyNameValue.setFamilyName("NonLatinBloggs");
+        nonLatinFamilyNameValue.setIsLatinScript(false);
+        familyName.getAttributeValues().add(nonLatinFamilyNameValue);
+
+        attributeStatementBuilder.addAttribute(familyName);
+
+        Attribute personIdentifier =  anAttribute(IdaConstants.Eidas_Attributes.PersonIdentifier.NAME);
+        PersonIdentifier personIdentifierValue = new PersonIdentifierBuilder().buildObject();
+        personIdentifierValue.setPersonIdentifier("JB12345");
+        personIdentifier.getAttributeValues().add(personIdentifierValue);
+        attributeStatementBuilder.addAttribute(personIdentifier);
+
+        Attribute dateOfBirth =  anAttribute(IdaConstants.Eidas_Attributes.DateOfBirth.NAME);
+        DateOfBirth dateOfBirthValue = new DateOfBirthBuilder().buildObject();
+        dateOfBirthValue.setDateOfBirth(LocalDate.now());
+        dateOfBirth.getAttributeValues().add(dateOfBirthValue);
+        attributeStatementBuilder.addAttribute(dateOfBirth);
+
+        org.opensaml.saml.saml2.core.Response samlResponse = aValidEidasResponse("requestId", appWithEidasEnabled.getCountryEntityId(),
+                attributeStatementBuilder.build()
+                ).build();
+        String base64Response = new XmlObjectToBase64EncodedStringTransformer().apply(samlResponse);
+        Response response = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
+                Entity.json(new TranslateSamlResponseBody(base64Response, "requestId", LEVEL_2, null))
+        );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        String body = response.readEntity(String.class);
+        JSONObject json = new JSONObject(body);
+        JSONObject attributes = json.getJSONObject("attributes");
+        JSONObject firstNames = attributes.getJSONArray("firstNames").getJSONObject(0);
+
+        assertThat(firstNames.getString("value")).isEqualTo("Joe");
+        assertThat(firstNames.getString("nonLatinScriptValue")).isEqualTo("NonLatinJoe");
+
+        JSONObject surnames = attributes.getJSONArray("surnames").getJSONObject(0);
+
+        assertThat(surnames.getString("value")).isEqualTo("Bloggs");
+        assertThat(surnames.getString("nonLatinScriptValue")).isEqualTo("NonLatinBloggs");
+    }
+
+    private Attribute anAttribute(String name) {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(name);
+        return attribute;
+    }
 
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections.CollectionUtils;
@@ -11,11 +12,11 @@ import java.util.List;
 public class NonMatchingAttributes {
 
     @JsonProperty("firstNames")
-    private final List<NonMatchingVerifiableAttribute<String>> firstNames;
+    private final List<NonMatchingTransliterableAttribute> firstNames;
     @JsonProperty("middleNames")
     private final List<NonMatchingVerifiableAttribute<String>> middleNames;
     @JsonProperty("surnames")
-    private final List<NonMatchingVerifiableAttribute<String>> surnames;
+    private final List<NonMatchingTransliterableAttribute> surnames;
     @JsonProperty("datesOfBirth")
     private final List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth;
     @JsonProperty("gender")
@@ -24,12 +25,19 @@ public class NonMatchingAttributes {
     private final List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses;
 
 
+    @JsonCreator
     public NonMatchingAttributes(
-            List<NonMatchingVerifiableAttribute<String>> firstNames,
+            @JsonProperty("firstNames")
+            List<NonMatchingTransliterableAttribute> firstNames,
+            @JsonProperty("middleNames")
             List<NonMatchingVerifiableAttribute<String>> middleNames,
-            List<NonMatchingVerifiableAttribute<String>> surnames,
+            @JsonProperty("surnames")
+            List<NonMatchingTransliterableAttribute> surnames,
+            @JsonProperty("datesOfBirth")
             List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth,
+            @JsonProperty("gender")
             NonMatchingVerifiableAttribute<Gender> gender,
+            @JsonProperty("addresses")
             List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses
     ) {
         this.firstNames = firstNames;
@@ -40,7 +48,7 @@ public class NonMatchingAttributes {
         this.addresses = addresses;
     }
 
-    public List<NonMatchingVerifiableAttribute<String>> getFirstNames() {
+    public List<NonMatchingTransliterableAttribute> getFirstNames() {
         return firstNames;
     }
 
@@ -48,7 +56,7 @@ public class NonMatchingAttributes {
         return middleNames;
     }
 
-    public List<NonMatchingVerifiableAttribute<String>> getSurnames() {
+    public List<NonMatchingTransliterableAttribute> getSurnames() {
         return surnames;
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingTransliterableAttribute.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingTransliterableAttribute.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public class NonMatchingTransliterableAttribute extends NonMatchingVerifiableAttribute<String> {
+
+    @JsonProperty("nonLatinScriptValue")
+    private final String nonLatinScriptValue;
+
+    public NonMatchingTransliterableAttribute(String value,
+                                              String nonLatinScriptValue,
+                                              boolean verified,
+                                              LocalDate from,
+                                              LocalDate to) {
+        super(value, verified, from, to);
+        this.nonLatinScriptValue = nonLatinScriptValue;
+    }
+
+    public String getNonLatinScriptValue() {
+        return nonLatinScriptValue;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TestTranslatedNonMatchingResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TestTranslatedNonMatchingResponseBody.java
@@ -3,8 +3,6 @@ package uk.gov.ida.verifyserviceprovider.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Optional;
-
 public class TestTranslatedNonMatchingResponseBody extends TranslatedNonMatchingResponseBody {
 
     @JsonCreator
@@ -24,9 +22,4 @@ public class TestTranslatedNonMatchingResponseBody extends TranslatedNonMatching
     public LevelOfAssurance getLevelOfAssurance() {
         return levelOfAssurance;
     }
-
-    public Optional<NonMatchingAttributes> getAttributes() {
-        return Optional.ofNullable(attributes);
-    }
-
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TranslatedNonMatchingResponseBody implements TranslatedResponseBody {
@@ -13,10 +14,15 @@ public class TranslatedNonMatchingResponseBody implements TranslatedResponseBody
     @JsonProperty("attributes")
     protected final NonMatchingAttributes attributes;
 
+    @JsonCreator
     public TranslatedNonMatchingResponseBody(
+            @JsonProperty("scenario")
             NonMatchingScenario scenario,
+            @JsonProperty("pid")
             String pid,
+            @JsonProperty("levelOfAssurance")
             LevelOfAssurance levelOfAssurance,
+            @JsonProperty("attributes")
             NonMatchingAttributes attributes
     ) {
         this.scenario = scenario;
@@ -28,6 +34,18 @@ public class TranslatedNonMatchingResponseBody implements TranslatedResponseBody
     @Override
     public Scenario getScenario() {
         return scenario;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public LevelOfAssurance getLevelOfAssurance() {
+        return levelOfAssurance;
+    }
+
+    public NonMatchingAttributes getAttributes() {
+        return attributes;
     }
 
     @Override

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -55,13 +55,13 @@ public class MatchingDatasetToNonMatchingAttributesMapper {
 
     private List<NonMatchingTransliterableAttribute> convertTransliterableNameAttributes(List<TransliterableMdsValue> values) {
         return values.stream()
-                .map(this::mapToNonMatchingVerifiableAttribute)
+                .map(this::mapToTransliterableAttribute)
                 .sorted(attributeComparator())
                 .collect(Collectors.toList());
     }
 
 
-    private NonMatchingTransliterableAttribute mapToNonMatchingVerifiableAttribute(TransliterableMdsValue transliterableMdsValue) {
+    private NonMatchingTransliterableAttribute mapToTransliterableAttribute(TransliterableMdsValue transliterableMdsValue) {
         LocalDate from = Optional.ofNullable(transliterableMdsValue.getFrom())
                 .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
                 .orElse(null);

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
@@ -9,6 +9,7 @@ import uk.gov.ida.saml.core.domain.SimpleMdsValue;
 import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAddress;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingTransliterableAttribute;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttributeBuilder;
 
@@ -65,6 +66,30 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
     }
 
     @Test
+    public void shouldMapFirstNamesWithNonLatinScriptValue() {
+        String nonLatinScript = "nonLatinScript";
+        List<TransliterableMdsValue> firstNames = asList(
+                createTransliterableValue(foo, nonLatinScript)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                firstNames,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingTransliterableAttribute nonMatchingTransliterableAttribute = nonMatchingAttributes.getFirstNames().get(0);
+        assertThat(nonMatchingTransliterableAttribute.getValue()).isEqualTo(foo);
+        assertThat(nonMatchingTransliterableAttribute.getNonLatinScriptValue()).isEqualTo(nonLatinScript);
+    }
+
+    @Test
     public void shouldMapMiddlenames() {
         List<SimpleMdsValue<String>> middleNames = asList(
                 createSimpleMdsValue(fromThree, foo),
@@ -118,6 +143,30 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
                 .collect(Collectors.toList()))
                 .isEqualTo(asList(baz, foo, bar, fuu));
         assertThat(nonMatchingAttributes.getSurnames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapSurnamesWithNonLatinScriptValue() {
+        String nonLatinScript = "nonLatinScript";
+        List<TransliterableMdsValue> surnames = asList(
+                createTransliterableValue(foo, nonLatinScript)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                surnames,
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingTransliterableAttribute nonMatchingTransliterableAttribute = nonMatchingAttributes.getSurnames().get(0);
+        assertThat(nonMatchingTransliterableAttribute.getValue()).isEqualTo(foo);
+        assertThat(nonMatchingTransliterableAttribute.getNonLatinScriptValue()).isEqualTo(nonLatinScript);
     }
 
     @Test
@@ -335,6 +384,10 @@ public class MatchingDatasetToNonMatchingAttributesMapperTest {
 
     private TransliterableMdsValue createTransliterableValue(DateTime from, String value) {
         return new TransliterableMdsValue(createSimpleMdsValue(from, value));
+    }
+
+    private TransliterableMdsValue createTransliterableValue(String value, String nonLatinScript) {
+        return new TransliterableMdsValue(value, nonLatinScript);
     }
 
     private SimpleMdsValue<String> createSimpleMdsValue(DateTime from, String value) {


### PR DESCRIPTION
This PR adds support for serializing the `nonLatinScriptValue` from eIDAS Assertions into the attributes returned from the VSP.