### PR TITLE
fix: don't serialize some null fields

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingAcceptanceTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.verifyserviceprovider.builders.VerifyServiceProviderAppRuleBuilder.aVerifyServiceProviderAppRule;
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_1;
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.AUTHENTICATION_FAILED;
 import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
 import static uk.gov.ida.verifyserviceprovider.services.ComplianceToolService.*;
 
@@ -360,10 +361,11 @@ public class NonMatchingAcceptanceTest {
                 .buildPost(json(translateResponseRequestData))
                 .invoke();
 
-        TestTranslatedNonMatchingResponseBody responseContent = response.readEntity(TestTranslatedNonMatchingResponseBody.class);
-
-        assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
-        assertThat(responseContent.getScenario()).isEqualTo(NonMatchingScenario.AUTHENTICATION_FAILED);
+        JSONObject jsonResponse = new JSONObject(response.readEntity(String.class));
+        assertThat(jsonResponse.getString("scenario")).isEqualTo(AUTHENTICATION_FAILED.name());
+        assertThat(jsonResponse.has("levelOfAssurance")).isFalse();
+        assertThat(jsonResponse.has("pid")).isFalse();
+        assertThat(jsonResponse.has("attributes")).isFalse();
     }
 
     @Test

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/TranslatedNonMatchingResponseBody.java
@@ -1,17 +1,18 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TranslatedNonMatchingResponseBody implements TranslatedResponseBody {
 
     @JsonProperty("scenario")
     private final NonMatchingScenario scenario;
-    @JsonProperty("pid")
+    @JsonProperty("pid") @JsonInclude(value = JsonInclude.Include.NON_NULL)
     protected final String pid;
-    @JsonProperty("levelOfAssurance")
+    @JsonProperty("levelOfAssurance") @JsonInclude(value = JsonInclude.Include.NON_NULL)
     protected final LevelOfAssurance levelOfAssurance;
-    @JsonProperty("attributes")
+    @JsonProperty("attributes") @JsonInclude(value = JsonInclude.Include.NON_NULL)
     protected final NonMatchingAttributes attributes;
 
     @JsonCreator


### PR DESCRIPTION
When a scenario is anything other than IDENTITY_VERIFIED the `pid`,
`levelOfAssurance`, and `attributes` are currently being serialized as
nulls. Instead, we should not serialize them at all.