### PR TITLE
bau: make loa request param optional

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
@@ -9,7 +9,6 @@ import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
-import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.RequestGenerationBody;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
 
@@ -23,9 +22,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.*;
 import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolV1InitialisationRequestBuilder.aComplianceToolV1InitialisationRequest;
 
@@ -82,6 +79,31 @@ public class AuthnRequestAcceptanceTest {
         ConfigOverride.config("europeanIdentity.trustStore.password", KEY_STORE_RESOURCE.getPassword())
     );
 
+    @Test
+    public void shouldGenerateValidAuthnRequestWhenNoParams() throws Exception {
+        Client client = new JerseyClientBuilder(singleTenantApplication.getEnvironment()).build("Test Client");
+
+        setupComplianceToolWithDefaultEntityId(client);
+
+        Response authnResponse = client
+                .target(URI.create(String.format("http://localhost:%d/generate-request", singleTenantApplication.getLocalPort())))
+                .request()
+                .buildPost(Entity.json(null))
+                .invoke();
+
+        RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
+
+        Response complianceToolResponse = client
+                .target(authnSaml.getSsoLocation())
+                .request()
+                .buildPost(Entity.form(new MultivaluedHashMap<>(ImmutableMap.of("SAMLRequest", authnSaml.getSamlRequest()))))
+                .invoke();
+
+        JSONObject complianceToolResponseBody = new JSONObject(complianceToolResponse.readEntity(String.class));
+        assertThat(complianceToolResponseBody.getJSONObject("status").get("message")).isEqualTo(null);
+        assertThat(complianceToolResponseBody.getJSONObject("status").getString("status")).isEqualTo("PASSED");
+    }
+
 
     @Test
     public void shouldGenerateValidAuthnRequestUsingDefaultEntityId() throws Exception {
@@ -92,7 +114,7 @@ public class AuthnRequestAcceptanceTest {
         Response authnResponse = client
             .target(URI.create(String.format("http://localhost:%d/generate-request", singleTenantApplication.getLocalPort())))
             .request()
-            .buildPost(Entity.json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)))
+            .buildPost(Entity.json(new RequestGenerationBody(null)))
             .invoke();
 
         RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
@@ -117,7 +139,7 @@ public class AuthnRequestAcceptanceTest {
         Response authnResponse = client
             .target(URI.create(String.format("http://localhost:%d/generate-request", multiTenantApplication.getLocalPort())))
             .request()
-            .buildPost(Entity.json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, MULTI_ENTITY_ID_1)))
+            .buildPost(Entity.json(new RequestGenerationBody(MULTI_ENTITY_ID_1)))
             .invoke();
 
         RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
@@ -142,7 +164,7 @@ public class AuthnRequestAcceptanceTest {
         Response authnResponse = client
             .target(URI.create(String.format("http://localhost:%d/generate-request", multiTenantApplication.getLocalPort())))
             .request()
-            .buildPost(Entity.json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)))
+            .buildPost(Entity.json(new RequestGenerationBody(null)))
             .invoke();
 
         assertThat(authnResponse.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());
@@ -157,7 +179,7 @@ public class AuthnRequestAcceptanceTest {
         Response authnResponse = client
             .target(URI.create(String.format("http://localhost:%d/generate-request", multiTenantApplication.getLocalPort())))
             .request()
-            .buildPost(Entity.json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, "not a valid entityID")))
+            .buildPost(Entity.json(new RequestGenerationBody("not a valid entityID")))
             .invoke();
 
         assertThat(authnResponse.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
@@ -22,7 +22,9 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.*;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
 import static uk.gov.ida.verifyserviceprovider.builders.ComplianceToolV1InitialisationRequestBuilder.aComplianceToolV1InitialisationRequest;
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/ComplianceToolModeAcceptanceTest.java
@@ -141,7 +141,7 @@ public class ComplianceToolModeAcceptanceTest {
         Response authnRequest = client
                 .target(appUri("generate-request"))
                 .request()
-                .post(json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)));
+                .post(json(null));
 
         RequestResponseBody authnSaml = authnRequest.readEntity(RequestResponseBody.class);
 
@@ -201,7 +201,7 @@ public class ComplianceToolModeAcceptanceTest {
         Response authnRequest = client
                 .target(appUri("generate-request"))
                 .request()
-                .post(json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)));
+                .post(json(new RequestGenerationBody(null)));
 
         assertThat(authnRequest.getStatus()).isEqualTo(200);
         RequestResponseBody authnSaml = authnRequest.readEntity(RequestResponseBody.class);
@@ -250,7 +250,7 @@ public class ComplianceToolModeAcceptanceTest {
         Response authnRequest = client
                 .target(appUri("generate-request"))
                 .request()
-                .post(json(new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null)));
+                .post(json(new RequestGenerationBody(null)));
 
         assertThat(authnRequest.getStatus()).isEqualTo(200);
         RequestResponseBody authnSaml = authnRequest.readEntity(RequestResponseBody.class);

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/GenerateRequestService.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/services/GenerateRequestService.java
@@ -7,7 +7,6 @@ import javax.ws.rs.client.Client;
 import java.net.URI;
 
 import static javax.ws.rs.client.Entity.json;
-import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 
 public class GenerateRequestService {
 
@@ -21,7 +20,7 @@ public class GenerateRequestService {
         return client
             .target(URI.create(String.format("http://localhost:%d/generate-request", localPort)))
             .request()
-            .buildPost(json(new RequestGenerationBody(LEVEL_2, null)))
+            .buildPost(json(new RequestGenerationBody(null)))
             .invoke()
             .readEntity(RequestResponseBody.class);
     }
@@ -30,7 +29,7 @@ public class GenerateRequestService {
         return client
             .target(URI.create(String.format("http://localhost:%d/generate-request", localPort)))
             .request()
-            .buildPost(json(new RequestGenerationBody(LEVEL_2, entityId)))
+            .buildPost(json(new RequestGenerationBody(entityId)))
             .invoke()
             .readEntity(RequestResponseBody.class);
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/RequestGenerationBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/RequestGenerationBody.java
@@ -3,8 +3,6 @@ package uk.gov.ida.verifyserviceprovider.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.validation.constraints.NotNull;
-
 public class RequestGenerationBody {
 
     private final LevelOfAssurance levelOfAssurance;
@@ -18,7 +16,6 @@ public class RequestGenerationBody {
         this.entityId = entityId;
     }
 
-    @NotNull
     public LevelOfAssurance getLevelOfAssurance() {
         return levelOfAssurance;
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/dto/RequestGenerationBody.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/dto/RequestGenerationBody.java
@@ -1,12 +1,18 @@
 package uk.gov.ida.verifyserviceprovider.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class RequestGenerationBody {
 
     private final LevelOfAssurance levelOfAssurance;
     private final String entityId;
+
+    public RequestGenerationBody(String entityId) {
+        this.levelOfAssurance = null;
+        this.entityId = entityId;
+    }
 
     @JsonCreator
     public RequestGenerationBody(
@@ -16,6 +22,7 @@ public class RequestGenerationBody {
         this.entityId = entityId;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public LevelOfAssurance getLevelOfAssurance() {
         return levelOfAssurance;
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactory.java
@@ -30,7 +30,6 @@ import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
 import uk.gov.ida.saml.security.SignatureFactory;
 import uk.gov.ida.shared.utils.manifest.ManifestReader;
 import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
-import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.factories.EncrypterFactory;
 
 import java.io.IOException;
@@ -60,7 +59,7 @@ public class AuthnRequestFactory {
         this.signingKeyPair = signingKeyPair;
     }
 
-    public AuthnRequest build(LevelOfAssurance levelOfAssurance, String serviceEntityId) {
+    public AuthnRequest build(String serviceEntityId) {
         AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
         authnRequest.setID(String.format("_%s", UUID.randomUUID()));
         authnRequest.setIssueInstant(DateTime.now());

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResource.java
@@ -8,8 +8,8 @@ import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
 import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -35,9 +35,9 @@ public class GenerateAuthnRequestResource {
     }
 
     @POST
-    public Response generateAuthnRequest(@NotNull @Valid RequestGenerationBody requestGenerationBody) {
+    public Response generateAuthnRequest(@Valid @Nullable RequestGenerationBody requestGenerationBody) {
         String entityId = entityIdService.getEntityId(requestGenerationBody);
-        AuthnRequest authnRequest = this.authnRequestFactory.build(requestGenerationBody.getLevelOfAssurance(), entityId);
+        AuthnRequest authnRequest = this.authnRequestFactory.build(entityId);
         XmlObjectToBase64EncodedStringTransformer xmlToBase64Transformer = new XmlObjectToBase64EncodedStringTransformer();
         String samlRequest = xmlToBase64Transformer.apply(authnRequest);
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EntityIdService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EntityIdService.java
@@ -6,7 +6,9 @@ import uk.gov.ida.verifyserviceprovider.dto.RequestGenerationBody;
 import uk.gov.ida.verifyserviceprovider.dto.TranslateSamlResponseBody;
 import uk.gov.ida.verifyserviceprovider.exceptions.InvalidEntityIdException;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 public class EntityIdService {
     private final List<String> configuredEntityIds;
@@ -18,8 +20,8 @@ public class EntityIdService {
         this.defaultEntityId = configuredEntityIds.size() == 1 ? configuredEntityIds.get(0) : null;
     }
 
-    public String getEntityId(RequestGenerationBody requestGenerationBody) {
-        String entityId = requestGenerationBody.getEntityId();
+    public String getEntityId(@Nullable RequestGenerationBody requestGenerationBody) {
+        String entityId = Optional.ofNullable(requestGenerationBody).map(RequestGenerationBody::getEntityId).orElse(null);
         LOG.info(String.format("Received request to generate authn request with entityId %s", entityId != null ? entityId : "from config"));
         return getEntityId(entityId);
     }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactoryTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/factories/saml/AuthnRequestFactoryTest.java
@@ -23,7 +23,6 @@ import uk.gov.ida.saml.core.test.TestEntityIds;
 import uk.gov.ida.saml.security.DecrypterFactory;
 import uk.gov.ida.shared.utils.manifest.ManifestReader;
 import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
-import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.factories.EncrypterFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
 
@@ -74,7 +73,7 @@ public class AuthnRequestFactoryTest {
 
     @Test
     public void containsCorrectAttributes() throws KeyException {
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
 
         assertThat(authnRequest.getID()).isNotEmpty();
         assertThat(authnRequest.getIssueInstant()).isNotNull();
@@ -85,25 +84,25 @@ public class AuthnRequestFactoryTest {
 
     @Test
     public void shouldNotForceAuthn() {
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
         assertThat(authnRequest.isForceAuthn()).isFalse();
     }
 
     @Test
     public void signatureIDReferencesAuthnRequestID() {
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
         assertThat(authnRequest.getSignatureReferenceID()).isEqualTo(authnRequest.getID());
     }
 
     @Test
     public void destinationShouldMatchConfiguredSSOLocation() {
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
         assertThat(authnRequest.getDestination()).isEqualTo(DESTINATION.toString());
     }
 
     @Test
     public void issuerShouldMatchConfiguredEntityID() {
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
         assertThat(authnRequest.getIssuer().getValue()).isEqualTo(SERVICE_ENTITY_ID);
     }
 
@@ -111,7 +110,7 @@ public class AuthnRequestFactoryTest {
     public void shouldAddApplicationVersionInExtension() throws Exception {
         when(manifestReader.getAttributeValueFor(VerifyServiceProviderApplication.class, "Version")).thenReturn("some-version");
 
-        AuthnRequest authnRequest = factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        AuthnRequest authnRequest = factory.build(SERVICE_ENTITY_ID);
 
         Extensions extensions = authnRequest.getExtensions();
         EncryptedAttribute encryptedAttribute = (EncryptedAttribute) extensions.getUnknownXMLObjects().get(0);
@@ -125,7 +124,7 @@ public class AuthnRequestFactoryTest {
 
     @Test
     public void shouldGetVersionNumberFromManifestReader() throws IOException, KeyException {
-        factory.build(LevelOfAssurance.LEVEL_2, SERVICE_ENTITY_ID);
+        factory.build(SERVICE_ENTITY_ID);
 
         verify(manifestReader, times(1)).getAttributeValueFor(VerifyServiceProviderApplication.class, "Version");
     }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
@@ -73,14 +73,21 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void returnsAnOKResponseWithoutLoaParam() {
-        when(authnRequestFactory.build(any(), any())).thenReturn(authnRequest);
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
         Response response = resources.target("/generate-request").request().post(Entity.entity(ImmutableMap.of(), MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 
     @Test
+    public void returnsAnOKResponseWhenNoParams() {
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
+        Response response = resources.target("/generate-request").request().post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
     public void returnsAnOKResponse() {
-        when(authnRequestFactory.build(any(), any())).thenReturn(authnRequest);
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
 
         Response response = resources.target("/generate-request").request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
@@ -89,7 +96,7 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void responseContainsExpectedFields() {
-        when(authnRequestFactory.build(any(), eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         assertThat(requestResponseBody.getSamlRequest()).isNotEmpty();
         assertThat(requestResponseBody.getRequestId()).isNotEmpty();
@@ -98,14 +105,14 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void ssoLocationIsSameAsConfiguration() {
-        when(authnRequestFactory.build(any(), eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         assertThat(requestResponseBody.getSsoLocation()).isEqualTo(HUB_SSO_LOCATION);
     }
 
     @Test
     public void samlRequestIsBase64EncodedAuthnRequest() {
-        when(authnRequestFactory.build(any(), eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         try {
             Base64.getDecoder().decode(requestResponseBody.getSamlRequest());
@@ -140,7 +147,7 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void returns500IfARuntimeExceptionIsThrown() {
-        when(authnRequestFactory.build(any(), any())).thenThrow(RuntimeException.class);
+        when(authnRequestFactory.build(any())).thenThrow(RuntimeException.class);
 
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
         Response response = resources.target("/generate-request").request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EntityIdServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EntityIdServiceTest.java
@@ -24,6 +24,12 @@ public class EntityIdServiceTest {
     }
 
     @Test
+    public void ShouldReturnDefaultEntityIdWhenNullBodyProvidedForSingleTenant_GenerateRequest() {
+        EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
+        assertThat(entityIdService.getEntityId((RequestGenerationBody)null)).isEqualTo(entityId);
+    }
+
+    @Test
     public void ShouldReturnDefaultEntityIdWhenNoneProvidedForSingleTenant_TranslateResponse() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, null);

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EntityIdServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EntityIdServiceTest.java
@@ -16,7 +16,7 @@ public class EntityIdServiceTest {
     private final String otherEntityId = "http://other.provided.entity.id";
 
     @Test
-    public void ShouldReturnDefaultEntityIdWhenNoneProvidedForSingleTenant_GenerateRequest() {
+    public void shouldReturnDefaultEntityIdWhenNoneProvidedForSingleTenantForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(null, null);
 
@@ -24,13 +24,13 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldReturnDefaultEntityIdWhenNullBodyProvidedForSingleTenant_GenerateRequest() {
+    public void shouldReturnDefaultEntityIdWhenNullBodyProvidedForSingleTenantForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         assertThat(entityIdService.getEntityId((RequestGenerationBody)null)).isEqualTo(entityId);
     }
 
     @Test
-    public void ShouldReturnDefaultEntityIdWhenNoneProvidedForSingleTenant_TranslateResponse() {
+    public void shouldReturnDefaultEntityIdWhenNoneProvidedForSingleTenantForTranslateResponse() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, null);
 
@@ -38,7 +38,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldReturnProvidedEntityIdWhenItIsInConfig_GenerateRequest() {
+    public void shouldReturnProvidedEntityIdWhenItIsInConfigForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(null, otherEntityId);
 
@@ -46,7 +46,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldReturnProvidedEntityIdWhenItIsInConfig_AuthnRequest() {
+    public void shouldReturnProvidedEntityIdWhenItIsInConfigForAuthnRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, otherEntityId);
 
@@ -54,7 +54,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldReturnProvidedEntityIdWhenItIsTheOnlyOneInConfig_GenerateRequest() {
+    public void shouldReturnProvidedEntityIdWhenItIsTheOnlyOneInConfigForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(null, entityId);
 
@@ -62,7 +62,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldReturnProvidedEntityIdWhenItIsTheOnlyOneInConfig_AuthnRequest() {
+    public void shouldReturnProvidedEntityIdWhenItIsTheOnlyOneInConfigForAuthnRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, entityId);
 
@@ -70,7 +70,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldThrowInvalidEntityIdExceptionWhenNoEntityIdIsProvidedForMultipleTenancy_GenerateRequest() {
+    public void shouldThrowInvalidEntityIdExceptionWhenNoEntityIdIsProvidedForMultipleTenancyForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(null, null);
 
@@ -80,7 +80,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldThrowInvalidEntityIdExceptionWhenNoEntityIdIsProvidedForMultipleTenancy_AuthnRequest() {
+    public void shouldThrowInvalidEntityIdExceptionWhenNoEntityIdIsProvidedForMultipleTenancyForAuthnRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, null);
 
@@ -90,7 +90,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldThrowInvalidEntityIdExceptionWhenEntityIdProvidedIsNotInConfig_GenerateRequest() {
+    public void shouldThrowInvalidEntityIdExceptionWhenEntityIdProvidedIsNotInConfigForGenerateRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(null, "http://some.other.entity.id");
 
@@ -100,7 +100,7 @@ public class EntityIdServiceTest {
     }
 
     @Test
-    public void ShouldThrowInvalidEntityIdExceptionWhenEntityIdProvidedIsNotInConfig_AuthnRequest() {
+    public void shouldThrowInvalidEntityIdExceptionWhenEntityIdProvidedIsNotInConfigForAuthnRequest() {
         EntityIdService entityIdService = new EntityIdService(Arrays.asList(entityId, otherEntityId));
         TranslateSamlResponseBody translateSamlResponseBody = new TranslateSamlResponseBody(null, null, null, "http://some.other.entity.id");
 


### PR DESCRIPTION
This parameter isn't used for anything so we can make it optional with
a view to phasing it out (or doing something with it) in the next
release.

It should be able to handle empty request bodies, '{}', and
'{"entityId": "foobar"}' bodies.

Also, removed the passing of 'levelOfAssurance' to objects where it's
never used.

Note: we've removed this parameter from our docs so if we don't remove it now then we need to fix the docs.