### PR TITLE
bau: upgrade to latest dropwizard

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,7 +40,7 @@ Changed metadata health check names to use the URI of the metadata they are tryi
 
 #### Dropwizard version
 
-This release uses Dropwizard 1.3.5.
+This release uses [Dropwizard 1.3.9](https://github.com/dropwizard/dropwizard/blob/v1.3.9/docs/source/about/release-notes.rst).
 
 ### 1.0.0
 [View Diff](https://github.com/alphagov/verify-service-provider/compare/0.4.0...1.0.0)

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ project.ext {
     openSamlVersion = '3.4.0'
     verifyCommonUtils = '2.0.0-337'
     samlLibVersion = "$openSamlVersion-174"
-    dropwizardVersion = '1.3.5'
+    dropwizardVersion = '1.3.9'
     jaxbapiVersion = '2.2.9'
     hub_saml="$openSamlVersion-15709"
 


### PR DESCRIPTION
There's a minor release that fixes a few things and includes a few CVEs. Release notes are [here](https://github.com/dropwizard/dropwizard/blob/v1.3.9/docs/source/about/release-notes.rst).