### PR TITLE
EID-1356:  Log AuthnRequest Attributes in the VSP using MDC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,14 @@ dependencies {
     testCompile(
         'junit:junit:4.12',
         "io.dropwizard:dropwizard-testing:$dropwizardVersion",
-        'org.mockito:mockito-core:2.23.4',
+        'org.mockito:mockito-core:2.24.5',
         "uk.gov.ida:saml-metadata-bindings-test:$samlLibVersion",
         "uk.gov.ida:saml-utils:$samlLibVersion",
         "uk.gov.ida:common-test-utils:2.0.0-44",
         "org.jsoup:jsoup:1.11.1",
-        "javax.xml.bind:jaxb-api:$jaxbapiVersion",
         "uk.gov.ida:hub-saml-test-utils:$hub_saml",
         "uk.gov.ida:saml-test-utils:$samlLibVersion",
+        "javax.activation:javax.activation-api:1.2.0",
     )
     testCompile('com.github.tomakehurst:wiremock:2.11.0'){ transitive = false }
 }
@@ -89,6 +89,11 @@ sourceSets {
         compileClasspath += sourceSets.main.runtimeClasspath
         compileClasspath += sourceSets.test.runtimeClasspath
         compileClasspath += sourceSets.test.output
+    }
+    test {
+        resources {
+            srcDir 'src/test/resources'
+        }
     }
 }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
@@ -7,6 +7,7 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 import uk.gov.ida.verifyserviceprovider.compliance.ComplianceToolMode;
@@ -54,6 +55,7 @@ public class VerifyServiceProviderApplication extends Application<VerifyServiceP
         bootstrap.addBundle(hubMetadataBundle);
         bootstrap.addBundle(msaMetadataBundle);
         bootstrap.addCommand(new ComplianceToolMode(bootstrap.getObjectMapper(), bootstrap.getValidatorFactory().getValidator(), this));
+        bootstrap.addBundle(new LogstashBundle());
     }
 
     @Override

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/logging/AuthnRequestAttributesHelper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/logging/AuthnRequestAttributesHelper.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.verifyserviceprovider.logging;
+
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class AuthnRequestAttributesHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthnRequestAttributesHelper.class);
+
+    public interface AuthnRequestAttibuteNames {
+        String REQUEST_ID = "requestId";
+        String DESTINATION = "destination";
+        String ISSUE_INSTANT = "issueInstant";
+        String ISSUER = "issuer";
+    }
+
+    public static void logAuthnRequestAttributes(AuthnRequest authnRequest) {
+        try {
+            MDC.put(AuthnRequestAttibuteNames.REQUEST_ID, authnRequest.getID() != null ? authnRequest.getID() : "");
+            MDC.put(AuthnRequestAttibuteNames.DESTINATION, authnRequest.getDestination() != null ? authnRequest.getDestination() : "");
+            MDC.put(AuthnRequestAttibuteNames.ISSUE_INSTANT, authnRequest.getIssueInstant() != null ? authnRequest.getIssueInstant().toString() : "");
+            MDC.put(AuthnRequestAttibuteNames.ISSUER, authnRequest.getIssuer() != null ? authnRequest.getIssuer().getValue() : "");
+            log.info("AuthnRequest Attributes: ");
+        } finally {
+            MDC.remove(AuthnRequestAttibuteNames.REQUEST_ID);
+            MDC.remove(AuthnRequestAttibuteNames.DESTINATION);
+            MDC.remove(AuthnRequestAttibuteNames.ISSUE_INSTANT);
+            MDC.remove(AuthnRequestAttibuteNames.ISSUER);
+        }
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResource.java
@@ -6,6 +6,7 @@ import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.verifyserviceprovider.dto.RequestGenerationBody;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
+import uk.gov.ida.verifyserviceprovider.logging.AuthnRequestAttributesHelper;
 import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
 
 import javax.annotation.Nullable;
@@ -44,6 +45,7 @@ public class GenerateAuthnRequestResource {
         RequestResponseBody requestResponseBody = new RequestResponseBody(samlRequest, authnRequest.getID(), ssoLocation);
 
         LOG.info(String.format("AuthnRequest generated for entityId: %s with requestId: %s", entityId, requestResponseBody.getRequestId()));
+        AuthnRequestAttributesHelper.logAuthnRequestAttributes(authnRequest);
         LOG.debug(String.format("AuthnRequest generated for entityId: %s with saml: %s", entityId, requestResponseBody.getSamlRequest()));
 
         return Response.ok(requestResponseBody).build();

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
@@ -1,16 +1,26 @@
 package unit.uk.gov.ida.verifyserviceprovider.resources;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
+import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.RequestGenerationBody;
@@ -19,45 +29,64 @@ import uk.gov.ida.verifyserviceprovider.exceptions.InvalidEntityIdExceptionMappe
 import uk.gov.ida.verifyserviceprovider.exceptions.JerseyViolationExceptionMapper;
 import uk.gov.ida.verifyserviceprovider.exceptions.JsonProcessingExceptionMapper;
 import uk.gov.ida.verifyserviceprovider.factories.saml.AuthnRequestFactory;
+import uk.gov.ida.verifyserviceprovider.logging.AuthnRequestAttributesHelper;
+import uk.gov.ida.verifyserviceprovider.logging.AuthnRequestAttributesHelper.AuthnRequestAttibuteNames;
 import uk.gov.ida.verifyserviceprovider.resources.GenerateAuthnRequestResource;
 import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.net.URI;
 import java.util.Base64;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GenerateAuthnRequestResourceTest {
 
+    private static final String GENERATE_REQUEST_RESOURCE_PATH = "/generate-request";
     private static final URI HUB_SSO_LOCATION = URI.create("http://example.com/SAML2/SSO");
-    private static final String defaultEntityId = "http://default-entity-id";
+    private static final String DEFAULT_ENTITY_ID = "http://default-entity-id";
+    private static final String TEST_REQUEST_ID = "request_id";
+    private static final String TEST_DESTINATION = "http://acme.service/authnRequest";
+    private static final String TEST_ISSUE_INSTANT = "2015-04-30T19:25:14.273Z";
+    private static final String TEST_ISSUER = "http://acme.service";
+    private static final String AUTHN_REQUEST_ATTRIBUTES_LOG_MESSAGE = "AuthnRequest Attributes:";
 
     private static AuthnRequestFactory authnRequestFactory = mock(AuthnRequestFactory.class);
     private static EntityIdService entityIdService = mock(EntityIdService.class);
+
+    private static final String publicBuild = System.getenv("VERIFY_USE_PUBLIC_BINARIES");
 
     private AuthnRequest authnRequest;
 
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
-        .addProvider(JerseyViolationExceptionMapper.class)
-        .addProvider(JsonProcessingExceptionMapper.class)
-        .addProvider(InvalidEntityIdExceptionMapper.class)
-        .addResource(new GenerateAuthnRequestResource(authnRequestFactory, HUB_SSO_LOCATION, entityIdService))
-        .build();
+            .addProvider(JerseyViolationExceptionMapper.class)
+            .addProvider(JsonProcessingExceptionMapper.class)
+            .addProvider(InvalidEntityIdExceptionMapper.class)
+            .addResource(new GenerateAuthnRequestResource(authnRequestFactory, HUB_SSO_LOCATION, entityIdService))
+            .build();
 
     @Before
     public void mockAuthnRequestFactory() {
         authnRequest = new AuthnRequestBuilder().buildObject();
-        authnRequest.setID("some-id");
+        authnRequest.setID(TEST_REQUEST_ID);
+        authnRequest.setDestination(TEST_DESTINATION);
+        authnRequest.setIssueInstant(DateTime.parse(TEST_ISSUE_INSTANT));
+        Issuer issuer = new IssuerBuilder().buildObject();
+        issuer.setValue(TEST_ISSUER);
+        authnRequest.setIssuer(issuer);
         reset(authnRequestFactory);
     }
 
@@ -68,20 +97,20 @@ public class GenerateAuthnRequestResourceTest {
 
     @Before
     public void mockEntityIdService() {
-        when(entityIdService.getEntityId(any(RequestGenerationBody.class))).thenReturn(defaultEntityId);
+        when(entityIdService.getEntityId(any(RequestGenerationBody.class))).thenReturn(DEFAULT_ENTITY_ID);
     }
 
     @Test
     public void returnsAnOKResponseWithoutLoaParam() {
         when(authnRequestFactory.build(any())).thenReturn(authnRequest);
-        Response response = resources.target("/generate-request").request().post(Entity.entity(ImmutableMap.of(), MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(Entity.entity(ImmutableMap.of(), MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 
     @Test
     public void returnsAnOKResponseWhenNoParams() {
         when(authnRequestFactory.build(any())).thenReturn(authnRequest);
-        Response response = resources.target("/generate-request").request().post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 
@@ -90,13 +119,13 @@ public class GenerateAuthnRequestResourceTest {
         when(authnRequestFactory.build(any())).thenReturn(authnRequest);
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
 
-        Response response = resources.target("/generate-request").request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 
     @Test
     public void responseContainsExpectedFields() {
-        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(DEFAULT_ENTITY_ID))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         assertThat(requestResponseBody.getSamlRequest()).isNotEmpty();
         assertThat(requestResponseBody.getRequestId()).isNotEmpty();
@@ -105,14 +134,14 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void ssoLocationIsSameAsConfiguration() {
-        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(DEFAULT_ENTITY_ID))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         assertThat(requestResponseBody.getSsoLocation()).isEqualTo(HUB_SSO_LOCATION);
     }
 
     @Test
     public void samlRequestIsBase64EncodedAuthnRequest() {
-        when(authnRequestFactory.build(eq(defaultEntityId))).thenReturn(authnRequest);
+        when(authnRequestFactory.build(eq(DEFAULT_ENTITY_ID))).thenReturn(authnRequest);
         RequestResponseBody requestResponseBody = generateRequest();
         try {
             Base64.getDecoder().decode(requestResponseBody.getSamlRequest());
@@ -121,10 +150,9 @@ public class GenerateAuthnRequestResourceTest {
         }
     }
 
-
     @Test
     public void returns422ForBadJson() {
-        Response response = resources.target("/generate-request")
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH)
                 .request()
                 .post(Entity.entity(ImmutableMap.of("bad", "json"), MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -135,13 +163,13 @@ public class GenerateAuthnRequestResourceTest {
 
     @Test
     public void returns422ForMalformedJson() {
-        Response response = resources.target("/generate-request")
-            .request()
-            .post(Entity.entity("this is not json", MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH)
+                .request()
+                .post(Entity.entity("this is not json", MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.readEntity(ErrorMessage.class)).isEqualTo(new ErrorMessage(
-            422,
-            "Unrecognized token 'this': was expecting 'null', 'true', 'false' or NaN")
+                422,
+                "Unrecognized token 'this': was expecting 'null', 'true', 'false' or NaN")
         );
     }
 
@@ -150,7 +178,7 @@ public class GenerateAuthnRequestResourceTest {
         when(authnRequestFactory.build(any())).thenThrow(RuntimeException.class);
 
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
-        Response response = resources.target("/generate-request").request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
 
         ErrorMessage responseEntity = response.readEntity(ErrorMessage.class);
         assertThat(responseEntity.getCode()).isEqualTo(500);
@@ -158,9 +186,102 @@ public class GenerateAuthnRequestResourceTest {
         assertThat(responseEntity.getDetails()).isNullOrEmpty();
     }
 
+    @Test
+    public void shouldLogAuthnRequestAttributesToMDC() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(AuthnRequestAttributesHelper.class);
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        logger.addAppender(appender);
+
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
+        RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
+
+        Response response =
+                resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(
+                        Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE)
+                );
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(appender).doAppend(loggingEventArgumentCaptor.capture());
+
+        ILoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
+        Map<String, String> mdcPropertyMap = loggingEvent.getMDCPropertyMap();
+
+
+        assertThat(loggingEvent.getMessage()).contains(AUTHN_REQUEST_ATTRIBUTES_LOG_MESSAGE);
+
+        assertThat(mdcPropertyMap.get(AuthnRequestAttibuteNames.REQUEST_ID)).isEqualTo(TEST_REQUEST_ID);
+        assertThat(mdcPropertyMap.get(AuthnRequestAttibuteNames.DESTINATION)).isEqualTo(TEST_DESTINATION);
+        assertThat(mdcPropertyMap.get(AuthnRequestAttibuteNames.ISSUE_INSTANT)).isEqualTo(TEST_ISSUE_INSTANT);
+        assertThat(mdcPropertyMap.get(AuthnRequestAttibuteNames.ISSUER)).isEqualTo(TEST_ISSUER);
+    }
+
+    @Test
+    public void shouldLogAuthnRequestAttributesToConsole() throws Exception {
+
+        ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();
+        PrintStream defaultConsolePrintStream = System.out;
+        System.setOut(new PrintStream(consoleOutput));
+
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
+        RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
+
+        Response response =
+                resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(
+                        Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE)
+                );
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        // Checking System.out does not work in a Travis build.  Only run this assertion outside of Travis.
+        if (! "true".equals(publicBuild)) {
+            assertThat(consoleOutput.toString()).contains(
+                    String.format("%s %s %s %s %s",
+                            AUTHN_REQUEST_ATTRIBUTES_LOG_MESSAGE,
+                            TEST_REQUEST_ID,
+                            TEST_DESTINATION,
+                            TEST_ISSUE_INSTANT,
+                            TEST_ISSUER
+                    )
+            );
+        }
+        System.setOut(defaultConsolePrintStream);
+    }
+
+    @Test
+    public void shouldLeaveMDCInPreviousStateAfterLogging() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(AuthnRequestAttributesHelper.class);
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        logger.addAppender(appender);
+
+        // Log and then Check state of MDC before calling the resource
+        MDC.put("testMDCKey", "testMDCValue");
+        logger.info("Do some logging to see what's on the MDC beforehand...");
+
+        ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(appender).doAppend(loggingEventArgumentCaptor.capture());
+
+        int mdcPropertyMapSizeBeforeCall = loggingEventArgumentCaptor.getValue().getMDCPropertyMap().size();
+
+        when(authnRequestFactory.build(any())).thenReturn(authnRequest);
+        RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
+
+        Response response =
+                resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(
+                        Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE)
+                );
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(appender, Mockito.times(2)).doAppend(loggingEventArgumentCaptor.capture());
+
+        // Resource should have added 4 items and then removed them from the MDC, leaving anything that was there previously
+        assertThat(loggingEventArgumentCaptor.getValue().getMDCPropertyMap().size()).isEqualTo(mdcPropertyMapSizeBeforeCall + 4);
+        assertThat(MDC.get("testMDCKey")).isEqualTo("testMDCValue");
+
+    }
+
     private RequestResponseBody generateRequest() {
         RequestGenerationBody requestGenerationBody = new RequestGenerationBody(LevelOfAssurance.LEVEL_2, null);
-        Response response = resources.target("/generate-request").request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
+        Response response = resources.target(GENERATE_REQUEST_RESOURCE_PATH).request().post(Entity.entity(requestGenerationBody, MediaType.APPLICATION_JSON_TYPE));
         return response.readEntity(RequestResponseBody.class);
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<!--
+    Logback Configuration for testing AuthnRequestAtrributesLogger usage of MDC.
+-->
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d %-5level [%thread] %logger{0}: %msg%n</pattern>
+        </encoder>
+    </appender>
+    <appender name="AuthnRequestAttributesLogger" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%msg%X{requestId} %X{destination} %X{issueInstant} %X{issuer}%n</pattern>
+        </encoder>
+    </appender>
+    <root level="TRACE">
+        <appender-ref ref="stdout"/>
+    </root>
+    <logger name="uk.gov.ida.verifyserviceprovider.logging.AuthnRequestAttributesHelper" level="INFO">
+        <appender-ref ref="AuthnRequestAttributesLogger"/>
+    </logger>
+</configuration>


### PR DESCRIPTION
Extra Attributes will be logged at info level for all VSP users.
Service VSP users will NOT see the logging format changed to json as this requires a config change that will only be applied in the Eidas Proxy Node.