### PR TITLE
BAU: Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/ci/dev-manifest-multi-tenant.yml
+++ b/ci/dev-manifest-multi-tenant.yml
@@ -1,6 +1,7 @@
 memory: 1024M
 applications:
   - name: verify-service-provider-dev-multi
+    stack: cflinuxfs3
     buildpack: java_buildpack
     env:
       CLOCK_SKEW: PT30s

--- a/ci/dev-manifest.yml
+++ b/ci/dev-manifest.yml
@@ -1,6 +1,7 @@
 memory: 1024M
 applications:
   - name: verify-service-provider-dev
+    stack: cflinuxfs3
     buildpack: java_buildpack
     env:
       CLOCK_SKEW: PT30s


### PR DESCRIPTION
The PaaS stack image cflinuxfs2 is being deprecated and needs to be
replace with cflinuxfs3 by end of April 2019.