### PR TITLE
BAU: Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/ci/dev-manifest-with-msa.yml
+++ b/ci/dev-manifest-with-msa.yml
@@ -1,6 +1,7 @@
 memory: 1024M
 applications:
   - name: vsp-with-matching-dev
+    stack: cflinuxfs3
     buildpack: java_buildpack
     command: (cd verify-service-provider-* && bin/verify-service-provider server vsp-with-matching.yml)
     env:

--- a/ci/integration-manifest.yml
+++ b/ci/integration-manifest.yml
@@ -3,6 +3,7 @@ applications:
     memory: 1G
     routes:
       - route: ((app)).apps.internal
+    stack: cflinuxfs3
     buildpack: java_buildpack
     command: (cd ((dist))-* && bin/((dist)) server ((config_file)) )
     env:

--- a/stub-msa-metadata/manifest.yml
+++ b/stub-msa-metadata/manifest.yml
@@ -2,4 +2,5 @@
 applications:
 - name: verify-service-provider-stub-msa-metadata
   memory: 64M
+  stack: cflinuxfs3
   buildpack: staticfile_buildpack


### PR DESCRIPTION
The PaaS stack image cflinuxfs2 is being deprecated and needs to be
replace with cflinuxfs3 by end of April 2019.

Related to PR#191, adding stack directive to additional manifests.