### PR TITLE
vGSUtQgY: Add staging manifest

### DIFF
--- a/ci/staging-manifest.yml
+++ b/ci/staging-manifest.yml
@@ -1,0 +1,15 @@
+applications:
+  - name: ((app))
+    memory: 1G
+    routes:
+      - route: ((app)).apps.internal
+    stack: cflinuxfs3
+    buildpack: java_buildpack
+    command: (cd ((dist))-* && bin/((dist)) server ((config_file)) )
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      CLOCK_SKEW: PT30s
+      EUROPEAN_IDENTITY_ENABLED: false
+      HUB_SSO_LOCATION: "https://www.staging.signin.service.gov.uk/SAML2/SSO"
+      HUB_METADATA_URL: "https://www.staging.signin.service.gov.uk/SAML2/metadata/federation"
+      TRUSTSTORE_PASSWORD: puppet


### PR DESCRIPTION
For the self-service app testing, we're deploying the test service to
the staging environment. The config for PaaS deployment includes the
environment variables required for the connection.

Concourse config changes: https://github.com/alphagov/verify-terraform/pull/936
Hub config changes: https://github.com/alphagov/verify-hub-federation-config/pull/357