### PR TITLE
Remove use of http stub rule

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/NonMatchingVerifyServiceProviderAppRule.java
@@ -1,63 +1,33 @@
 package uk.gov.ida.verifyserviceprovider.rules;
 
 import certificates.values.CACertificates;
-import com.nimbusds.jose.JOSEException;
-import httpstub.HttpStubRule;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockMetadataAggregatorServer;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockTrustAnchorServer;
+import common.uk.gov.ida.verifyserviceprovider.servers.MockVerifyHubServer;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import keystore.KeyStoreResource;
 import keystore.builders.KeyStoreResourceBuilder;
-import org.joda.time.DateTime;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 import org.opensaml.core.config.InitializationService;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
-import org.opensaml.saml.saml2.metadata.KeyDescriptor;
-import org.opensaml.xmlsec.signature.Signature;
-import uk.gov.ida.Constants;
-import uk.gov.ida.common.shared.security.PrivateKeyFactory;
-import uk.gov.ida.common.shared.security.X509CertificateFactory;
-import uk.gov.ida.eidas.trustanchor.Generator;
-import uk.gov.ida.saml.core.test.TestCertificateStrings;
-import uk.gov.ida.saml.core.test.TestCredentialFactory;
-import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
-import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
-import uk.gov.ida.saml.core.test.builders.metadata.IdpSsoDescriptorBuilder;
-import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
-import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 import uk.gov.ida.verifyserviceprovider.VerifyServiceProviderApplication;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 
-import javax.ws.rs.core.MediaType;
-import java.security.PrivateKey;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.X509Certificate;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-
-import static java.util.Collections.singletonList;
-import static uk.gov.ida.common.shared.security.Certificate.BEGIN_CERT;
-import static uk.gov.ida.common.shared.security.Certificate.END_CERT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.TEST_RP;
-import static uk.gov.ida.saml.metadata.ResourceEncoder.entityIdAsResource;
 
 public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServiceProviderConfiguration> {
 
-    private static final String VERIFY_METADATA_PATH = "/verify-metadata";
-    private static final String TRUST_ANCHOR_PATH = "/trust-anchor";
     private static final String METADATA_AGGREGATOR_PATH = "/metadata-aggregator";
     private static final String COUNTRY_METADATA_PATH = "/test-country";
-    private static final String METADATA_SOURCE_PATH = "/metadata-source";
 
-    private static final HttpStubRule metadataAggregatorServer = new HttpStubRule();
-    private static final HttpStubRule trustAnchorServer = new HttpStubRule();
-    private static final HttpStubRule verifyMetadataServer = new HttpStubRule();
+    private static final MockMetadataAggregatorServer metadataAggregatorServer = new MockMetadataAggregatorServer();
+    private static final MockTrustAnchorServer trustAnchorServer = new MockTrustAnchorServer();
+    private static final MockVerifyHubServer verifyMetadataServer = new MockVerifyHubServer();
     private String countryEntityId;
 
     private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
@@ -75,7 +45,7 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
                 ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
                 ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
                 ConfigOverride.config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
-                ConfigOverride.config("verifyHubConfiguration.metadata.uri", () -> "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
+                ConfigOverride.config("verifyHubConfiguration.metadata.uri", verifyMetadataServer::getUri),
                 ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
                 ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", metadataTrustStore.getPassword()),
                 ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY)
@@ -90,9 +60,10 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
                 ConfigOverride.config("hashingEntityId", "some-hashing-entity-id"),
                 ConfigOverride.config("server.connector.port", String.valueOf(0)),
                 ConfigOverride.config("logging.loggers.uk\\.gov", "DEBUG"),
+                ConfigOverride.config("logging.level", "WARN"),
                 ConfigOverride.config("samlSigningKey", TEST_RP_PRIVATE_SIGNING_KEY),
                 ConfigOverride.config("verifyHubConfiguration.environment", "COMPLIANCE_TOOL"),
-                ConfigOverride.config("verifyHubConfiguration.metadata.uri", () -> "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
+                ConfigOverride.config("verifyHubConfiguration.metadata.uri", verifyMetadataServer::getUri),
                 ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
                 ConfigOverride.config("verifyHubConfiguration.metadata.trustStore.password", metadataTrustStore.getPassword()),
                 ConfigOverride.config("verifyHubConfiguration.metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
@@ -102,8 +73,8 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
                 ConfigOverride.config("samlPrimaryEncryptionKey", TEST_RP_PRIVATE_ENCRYPTION_KEY),
                 ConfigOverride.config("europeanIdentity.hubConnectorEntityId", HUB_CONNECTOR_ENTITY_ID),
                 ConfigOverride.config("europeanIdentity.enabled", isEidasEnabled ? "true" : "false"),
-                ConfigOverride.config("europeanIdentity.trustAnchorUri", "http://localhost:" + trustAnchorServer.getPort() + TRUST_ANCHOR_PATH),
-                ConfigOverride.config("europeanIdentity.metadataSourceUri", "http://localhost:" + metadataAggregatorServer.getPort() + METADATA_SOURCE_PATH),
+                ConfigOverride.config("europeanIdentity.trustAnchorUri", trustAnchorServer::getUri),
+                ConfigOverride.config("europeanIdentity.metadataSourceUri", metadataAggregatorServer::getUri),
                 ConfigOverride.config("europeanIdentity.trustStore.path", countryMetadataTrustStore.getAbsolutePath()),
                 ConfigOverride.config("europeanIdentity.trustStore.password", countryMetadataTrustStore.getPassword())
         );
@@ -120,56 +91,24 @@ public class NonMatchingVerifyServiceProviderAppRule extends DropwizardAppRule<V
 
         try {
             InitializationService.initialize();
-            String testCountryMetadata = new MetadataFactory().singleEntityMetadata(buildTestCountryEntityDescriptor());
 
-            verifyMetadataServer.reset();
-            verifyMetadataServer.register(VERIFY_METADATA_PATH, 200, Constants.APPLICATION_SAMLMETADATA_XML, new MetadataFactory().defaultMetadata());
+            verifyMetadataServer.serveDefaultMetadata();
 
-            trustAnchorServer.reset();
-            trustAnchorServer.register(TRUST_ANCHOR_PATH, 200, MediaType.APPLICATION_OCTET_STREAM, buildTrustAnchorString(countryEntityId));
+            trustAnchorServer.serveTrustAnchor(countryEntityId);
 
-            metadataAggregatorServer.reset();
-            metadataAggregatorServer.register(METADATA_SOURCE_PATH + "/" + entityIdAsResource(countryEntityId), 200, Constants.APPLICATION_SAMLMETADATA_XML, testCountryMetadata);
+            metadataAggregatorServer.serveAggregatedMetadata(countryEntityId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
         super.before();
     }
 
-    private String buildTrustAnchorString(String countryEntityId) throws JOSEException, CertificateEncodingException {
-        X509CertificateFactory x509CertificateFactory = new X509CertificateFactory();
-        PrivateKey trustAnchorKey = new PrivateKeyFactory().createPrivateKey(Base64.getDecoder().decode(METADATA_SIGNING_A_PRIVATE_KEY));
-        X509Certificate trustAnchorCert = x509CertificateFactory.createCertificate(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT);
-        Generator generator = new Generator(trustAnchorKey, trustAnchorCert);
-        HashMap<String, List<X509Certificate>> trustAnchorMap = new HashMap<>();
-        X509Certificate metadataCACert = x509CertificateFactory.createCertificate(CACertificates.TEST_METADATA_CA.replace(BEGIN_CERT, "").replace(END_CERT, "").replace("\n", ""));
-        trustAnchorMap.put(countryEntityId, singletonList(metadataCACert));
-        return generator.generateFromMap(trustAnchorMap).serialize();
-    }
-
-    private EntityDescriptor buildTestCountryEntityDescriptor() throws Exception {
-        KeyDescriptor signingKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor()
-                .withX509ForSigning(STUB_COUNTRY_PUBLIC_PRIMARY_CERT)
-                .build();
-
-        IDPSSODescriptor idpSsoDescriptor = IdpSsoDescriptorBuilder.anIdpSsoDescriptor()
-                .withoutDefaultSigningKey()
-                .addKeyDescriptor(signingKeyDescriptor)
-                .build();
-
-        Signature signature = SignatureBuilder.aSignature()
-                .withSigningCredential(new TestCredentialFactory(METADATA_SIGNING_A_PUBLIC_CERT, METADATA_SIGNING_A_PRIVATE_KEY).getSigningCredential())
-                .withX509Data(METADATA_SIGNING_A_PUBLIC_CERT)
-                .build();
-
-        return EntityDescriptorBuilder.anEntityDescriptor()
-                .withEntityId(countryEntityId)
-                .withIdpSsoDescriptor(idpSsoDescriptor)
-                .setAddDefaultSpServiceDescriptor(false)
-                .withValidUntil(DateTime.now().plusWeeks(2))
-                .withSignature(signature)
-                .build();
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return RuleChain.outerRule(verifyMetadataServer)
+            .around(trustAnchorServer)
+            .around(metadataAggregatorServer)
+            .around(super::apply).apply(base, description);
     }
 
     public String getCountryEntityId() {

--- a/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockMetadataAggregatorServer.java
+++ b/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockMetadataAggregatorServer.java
@@ -1,0 +1,73 @@
+package common.uk.gov.ida.verifyserviceprovider.servers;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.IdpSsoDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.SignatureBuilder;
+import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.metadata.ResourceEncoder.entityIdAsResource;
+
+public class MockMetadataAggregatorServer extends WireMockClassRule {
+
+    public static final String METADATA_SOURCE_PATH = "/metadata-source";
+
+    public MockMetadataAggregatorServer() {
+        super(wireMockConfig().dynamicPort());
+    }
+
+    public void serveAggregatedMetadata(String entityId) throws Exception {
+        stubFor(
+            get(urlEqualTo(METADATA_SOURCE_PATH + "/" + entityIdAsResource(entityId)))
+                .willReturn(aResponse()
+                    .withStatus(200)
+                    .withBody(buildTestCountryEntityDescriptor(entityId))
+                )
+        );
+    }
+
+    public String getUri() {
+        return "http://localhost:" + port() + METADATA_SOURCE_PATH;
+    }
+
+    private String buildTestCountryEntityDescriptor(String countryEntityId) throws Exception {
+        KeyDescriptor signingKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor()
+            .withX509ForSigning(STUB_COUNTRY_PUBLIC_PRIMARY_CERT)
+            .build();
+
+        IDPSSODescriptor idpSsoDescriptor = IdpSsoDescriptorBuilder.anIdpSsoDescriptor()
+            .withoutDefaultSigningKey()
+            .addKeyDescriptor(signingKeyDescriptor)
+            .build();
+
+        Signature signature = SignatureBuilder.aSignature()
+            .withSigningCredential(new TestCredentialFactory(METADATA_SIGNING_A_PUBLIC_CERT, METADATA_SIGNING_A_PRIVATE_KEY).getSigningCredential())
+            .withX509Data(METADATA_SIGNING_A_PUBLIC_CERT)
+            .build();
+
+        EntityDescriptor entityDescriptor = EntityDescriptorBuilder.anEntityDescriptor()
+            .withEntityId(countryEntityId)
+            .withIdpSsoDescriptor(idpSsoDescriptor)
+            .setAddDefaultSpServiceDescriptor(false)
+            .withValidUntil(DateTime.now().plusWeeks(2))
+            .withSignature(signature)
+            .build();
+
+        String s = new MetadataFactory().singleEntityMetadata(entityDescriptor);
+        return s;
+    }
+}

--- a/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockTrustAnchorServer.java
+++ b/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockTrustAnchorServer.java
@@ -1,0 +1,58 @@
+package common.uk.gov.ida.verifyserviceprovider.servers;
+
+import certificates.values.CACertificates;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.nimbusds.jose.JOSEException;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.eidas.trustanchor.Generator;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.singletonList;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
+
+public class MockTrustAnchorServer extends WireMockClassRule {
+
+    public static final String TRUST_ANCHOR = "/trust-anchor";
+
+    private String buildTrustAnchorString(String countryEntityId) throws JOSEException, CertificateEncodingException {
+        X509CertificateFactory x509CertificateFactory = new X509CertificateFactory();
+        PrivateKey trustAnchorKey = new PrivateKeyFactory().createPrivateKey(Base64.getDecoder().decode(METADATA_SIGNING_A_PRIVATE_KEY));
+        X509Certificate trustAnchorCert = x509CertificateFactory.createCertificate(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT);
+        Generator generator = new Generator(trustAnchorKey, trustAnchorCert);
+        HashMap<String, List<X509Certificate>> trustAnchorMap = new HashMap<>();
+        String encoded = CACertificates.TEST_METADATA_CA;
+        X509Certificate metadataCACert = x509CertificateFactory.createCertificate(encoded);
+        trustAnchorMap.put(countryEntityId, singletonList(metadataCACert));
+        return generator.generateFromMap(trustAnchorMap).serialize();
+    }
+
+    public MockTrustAnchorServer() {
+        super(wireMockConfig().dynamicPort());
+    }
+
+    public void serveTrustAnchor(String entityId) throws CertificateEncodingException, JOSEException {
+        stubFor(
+            get(urlEqualTo(TRUST_ANCHOR))
+                .willReturn(aResponse()
+                    .withStatus(200)
+                    .withBody(buildTrustAnchorString(entityId))
+                )
+        );
+    }
+
+    public String getUri() {
+        return String.format("http://localhost:%s/%s", this.port(), TRUST_ANCHOR);
+    }
+}

--- a/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockVerifyHubServer.java
+++ b/src/test/java/common/uk/gov/ida/verifyserviceprovider/servers/MockVerifyHubServer.java
@@ -10,17 +10,23 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 public class MockVerifyHubServer extends WireMockClassRule {
 
+    public static final String METADATA = "/SAML2/metadata";
+
     public MockVerifyHubServer(){
         super(wireMockConfig().dynamicPort());
     }
 
     public void serveDefaultMetadata() {
         stubFor(
-            get(urlEqualTo("/SAML2/metadata"))
+            get(urlEqualTo(METADATA))
                 .willReturn(aResponse()
                     .withStatus(200)
                     .withBody(new MetadataFactory().defaultMetadata())
                 )
         );
+    }
+
+    public String getUri() {
+        return "http://localhost:" + port() + METADATA;
     }
 }


### PR DESCRIPTION
This replaces some usages of HTTPStubRule with wiremock which is our preferred library for mock HTTP services.