### PR TITLE
DEUtoBzK Added new production manifest to the VSP

### DIFF
--- a/ci/production-manifest.yml
+++ b/ci/production-manifest.yml
@@ -1,0 +1,13 @@
+applications:
+  - name: ((app))
+    memory: 1G
+    routes:
+      - route: ((app)).apps.internal
+    stack: cflinuxfs3
+    buildpack: java_buildpack
+    command: (cd ((dist))-* && bin/((dist)) server ((config_file)) )
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      CLOCK_SKEW: PT30s
+      VERIFY_ENVIRONMENT: PRODUCTION
+      EUROPEAN_IDENTITY_ENABLED: true


### PR DESCRIPTION
We need a product version of the VSP in the hub for testing against this change creates a new configuration file for the VSP for production.