### PR TITLE
PeUHqcqv: constraint to stop eIDAS and MSA config being set together

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/rules/VerifyServiceProviderAppRule.java
@@ -63,13 +63,7 @@ public class VerifyServiceProviderAppRule extends DropwizardAppRule<VerifyServic
                 msaServer.serveDefaultMetadata();
                 return msaServer.getUri();
             }),
-            ConfigOverride.config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID),
-            ConfigOverride.config("europeanIdentity.enabled", isEidasEnabled ? "true" : "false"),
-            ConfigOverride.config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
-            ConfigOverride.config("europeanIdentity.trustAnchorUri", "http://dummy.com"),
-            ConfigOverride.config("europeanIdentity.metadataSourceUri", "http://dummy.com"),
-            ConfigOverride.config("europeanIdentity.trustStore.path", KEY_STORE_RESOURCE.getAbsolutePath()),
-            ConfigOverride.config("europeanIdentity.trustStore.password", KEY_STORE_RESOURCE.getPassword())
+            ConfigOverride.config("msaMetadata.expectedEntityId", MockMsaServer.MSA_ENTITY_ID)
         );
     }
 

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/MsaMetadataFeatureTest.java
@@ -84,13 +84,7 @@ public class MsaMetadataFeatureTest {
             config("verifyHubConfiguration.metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
             config("verifyHubConfiguration.metadata.hubTrustStore.password", hubTrustStore.getPassword()),
             config("verifyHubConfiguration.metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
-            config("verifyHubConfiguration.metadata.idpTrustStore.password", idpTrustStore.getPassword()),
-            config("europeanIdentity.enabled", "false"),
-            config("europeanIdentity.hubConnectorEntityId", "dummyEntity"),
-            config("europeanIdentity.trustAnchorUri", "http://dummy.com"),
-            config("europeanIdentity.metadataSourceUri", "http://dummy.com"),
-            config("europeanIdentity.trustStore.path", metadataTrustStore.getAbsolutePath()),
-            config("europeanIdentity.trustStore.password", metadataTrustStore.getPassword())
+            config("verifyHubConfiguration.metadata.idpTrustStore.password", idpTrustStore.getPassword())
         );
 
         environmentHelper.setEnv(new HashMap<String, String>() {{

--- a/src/test/resources/verify-service-provider-with-msa-and-eidas.yml
+++ b/src/test/resources/verify-service-provider-with-msa-and-eidas.yml
@@ -54,3 +54,13 @@ samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
 msaMetadata:
   uri: ${MSA_METADATA_URL:-}
   expectedEntityId: ${MSA_ENTITY_ID:-}
+
+europeanIdentity:
+  enabled: ${EUROPEAN_IDENTITY_ENABLED}
+  hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
+  trustAnchorUri: ${TRUST_ANCHOR_URI}
+  metadataSourceUri: ${METADATA_SOURCE_URI}
+  trustStore:
+    path: ${TRUSTSTORE_PATH}/ida_metadata_truststore.ts
+    password: ${TRUSTSTORE_PASSWORD}
+  jerseyClientName: trust-anchor-client


### PR DESCRIPTION
This change adds a constraint to the VSP's config so that the `europeanIdentity` and `msa` configuration can't be set at the same time. Setting this behavior together shouldn't work as the two modes are mutually exclusive. eIDAS support on the VSP is only needed when its acting in a standalone capacity.