### PR TITLE
EID-1508: Add Dropwizard json logging library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ project.ext {
 dependencies {
     compile(
         "io.dropwizard:dropwizard-core:$dropwizardVersion",
-        'org.json:json:20171018',
+        "io.dropwizard:dropwizard-json-logging:${dropwizardVersion}",
+        "org.json:json:20171018",
         "org.opensaml:opensaml-core:$openSamlVersion",
         "org.opensaml:opensaml-saml-impl:$openSamlVersion",
         "uk.gov.ida:saml-metadata-bindings:$samlLibVersion",


### PR DESCRIPTION
This allows the app to be configured to format the app and request logs as JSON.
This is needed for the VSP instance used by the Proxy Node, as explained in alphagov/verify-proxy-node#227