### PR TITLE
fix: Use consistent naming for identity dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can use the following command line options to customise the behaviour of the
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
-| `-d MATCHINGDATASET` or <br> `--matchingDataset MATCHINGDATASET`| The identity dataset the testing service will use | [Test identity dataset][identity-dataset] |
+| `-d IDENTITYDATASET` or <br> `--identityDataset IDENTITYDATASET`| The identity dataset the testing service will use | [Test identity dataset][identity-dataset] |
 |`-u URL` or<br> `--url URL` | The URL where the testing service will send responses | `http://localhost:8080/SAML2/Response` |
 |`-t TIMEOUT` or<br> `--timeout TIMEOUT` | The timeout in seconds when communicating with the testing service | `5` |
 | `-p PORT` or<br> `--port PORT` | The port the service will use | `50300` |

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/RefreshDatasetResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/RefreshDatasetResource.java
@@ -11,7 +11,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/refresh-matching-dataset")
+@Path("/refresh-{a:matching|identity}-dataset")
 public class RefreshDatasetResource {
     private final ComplianceToolClient complianceToolClient;
 
@@ -23,8 +23,7 @@ public class RefreshDatasetResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Response execute(@Valid @NotNull MatchingDataset matchingDataset) throws Exception {
-        Response response = complianceToolClient.initializeComplianceTool(matchingDataset);
-        return response;
+        return complianceToolClient.initializeComplianceTool(matchingDataset);
 
     }
 

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/RefreshDatasetResourceTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/compliance/RefreshDatasetResourceTest.java
@@ -28,7 +28,10 @@ public class RefreshDatasetResourceTest {
 
     @Test
     public void itWillErrorIfTheMatchingDatasetIsNotValid() {
-        Response response = refreshDatasetResource.client().target("/refresh-matching-dataset").request().post(json("{}"));
+        Response response = refreshDatasetResource.client()
+            .target("/refresh-matching-dataset")
+            .request()
+            .post(json("{}"));
         assertThat(response.getStatus()).isEqualTo(422);
         ValidationErrorMessage errorMessage = response.readEntity(ValidationErrorMessage.class);
         assertThat(errorMessage.getErrors()).isNotEmpty();
@@ -38,7 +41,21 @@ public class RefreshDatasetResourceTest {
     @Test
     public void willCallOnTheComplianceToolIfTheMatchingDatasetIsValid() throws CertificateEncodingException {
         when(complianceToolClient.initializeComplianceTool(any(MatchingDataset.class))).thenReturn(Response.ok().build());
-        Response response = refreshDatasetResource.client().target("/refresh-matching-dataset").request().post(json(new MatchingDatasetBuilder().build()));
+        Response response = refreshDatasetResource.client()
+            .target("/refresh-matching-dataset")
+            .request()
+            .post(json(new MatchingDatasetBuilder().build()));
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(complianceToolClient).initializeComplianceTool(any(MatchingDataset.class));
+    }
+
+    @Test
+    public void willAlsoLetYouUseRefreshIdentityDataset() throws CertificateEncodingException {
+        when(complianceToolClient.initializeComplianceTool(any(MatchingDataset.class))).thenReturn(Response.ok().build());
+        Response response = refreshDatasetResource.client()
+            .target("/refresh-identity-dataset")
+            .request()
+            .post(json(new MatchingDatasetBuilder().build()));
         assertThat(response.getStatus()).isEqualTo(200);
         verify(complianceToolClient).initializeComplianceTool(any(MatchingDataset.class));
     }


### PR DESCRIPTION
Previously, we agreed to refer to the dataset returned by the standalone VSP
as the identity dataset. This change updates a resource in development
mode to follow the same naming convention. It also fixes a mistake in
the README which used the wrong name for a command line option