### PR TITLE
support private keys on the filesystem

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/compliance/ComplianceToolModeConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.verifyserviceprovider.configuration.HubEnvironment;
+import uk.gov.ida.verifyserviceprovider.configuration.TransparentPrivateKeyFactory;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyHubConfiguration;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 
@@ -23,14 +24,15 @@ public class ComplianceToolModeConfiguration extends VerifyServiceProviderConfig
 
     public ComplianceToolModeConfiguration(String serviceEntityId, KeysAndCert signingKeysAndCert, KeysAndCert encryptionKeysAndCert) {
         super(asList(serviceEntityId),
-              serviceEntityId,
-              new VerifyHubConfiguration(HubEnvironment.COMPLIANCE_TOOL),
-              signingKeysAndCert.getPrivate(),
-              encryptionKeysAndCert.getPrivate(),
-              encryptionKeysAndCert.getPrivate(),
-              Optional.empty(),
-              org.joda.time.Duration.standardMinutes(2),
-              Optional.empty());
+            serviceEntityId,
+            new VerifyHubConfiguration(HubEnvironment.COMPLIANCE_TOOL),
+            new TransparentPrivateKeyFactory(signingKeysAndCert.getPrivate()),
+            new TransparentPrivateKeyFactory(encryptionKeysAndCert.getPrivate()),
+            new TransparentPrivateKeyFactory(encryptionKeysAndCert.getPrivate()),
+            Optional.empty(),
+            org.joda.time.Duration.standardMinutes(2),
+            Optional.empty()
+        );
 
         this.serviceEntityId = serviceEntityId;
         this.signingKeysAndCert = signingKeysAndCert;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -17,13 +17,15 @@ public class EuropeanIdentityConfiguration extends EidasMetadataConfiguration {
 
     private TrustStoreConfiguration trustStoreConfiguration;
     private String hubConnectorEntityId;
+
+    @NotNull @Valid
     private boolean enabled;
     private HubEnvironment environment;
 
 
     @JsonCreator
     public EuropeanIdentityConfiguration(@JsonProperty("hubConnectorEntityId") String hubConnectorEntityId,
-                                         @NotNull @Valid @JsonProperty("enabled") boolean enabled,
+                                         @JsonProperty("enabled") boolean enabled,
                                          @JsonProperty("trustAnchorUri") URI trustAnchorUri,
                                          @JsonProperty("minRefreshDelay") Long minRefreshDelay,
                                          @JsonProperty("maxRefreshDelay") Long maxRefreshDelay,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/InlineEncodedKeyFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/InlineEncodedKeyFactory.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.validation.ValidationMethod;
+import jersey.repackaged.com.google.common.cache.CacheLoader;
+
+import java.security.PrivateKey;
+import java.util.Base64;
+
+@JsonTypeName("inline")
+public class InlineEncodedKeyFactory extends PrivateKeyFactory {
+    private final String value;
+
+    private CacheLoader<String, PrivateKey> loader = CacheLoader.from(key -> getPrivateKeyFromValue());;
+
+    public InlineEncodedKeyFactory(String value) {
+        this.value = value;
+//        this.privateKey = getPrivateKeyFromValue(value);
+    }
+
+    @Override
+    public PrivateKey getPrivateKey() {
+        return loadPrivateKey();
+    }
+
+    @ValidationMethod(message =
+        "A private key is not loadable. Keys must be provided as base64 encoded PKCS8 RSA private keys")
+    @JsonIgnore @SuppressWarnings(value = "unused")
+    public boolean isKeyLoadable() {
+       return loadPrivateKey() != null;
+    }
+
+    private PrivateKey loadPrivateKey() {
+        try {
+            return loader.load("key");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private PrivateKey getPrivateKeyFromValue() {
+        return getPrivateKeyFromBytes(Base64.getDecoder().decode(value));
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/PrivateKeyFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/PrivateKeyFactory.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.security.PrivateKey;
+
+/* There is a bug being tracked here - https://github.com/FasterXML/jackson-databind/issues/1358
+preventing us from deserializing directly to one of the JsonSubTypes when there is a defaultImpl
+defined. This can be avoided by only ever to deserialize to the super type (PrivateKeyFactory) */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    defaultImpl = InlineEncodedKeyFactory.class)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = PrivateKeyFileConfiguration.class, name = "file"),
+    @JsonSubTypes.Type(value = InlineEncodedKeyFactory.class, name = "inline"),
+})
+public abstract class PrivateKeyFactory {
+    public abstract PrivateKey getPrivateKey();
+
+    protected PrivateKey getPrivateKeyFromBytes(byte[] privateKey) {
+        uk.gov.ida.common.shared.security.PrivateKeyFactory privateKeyFactory = new uk.gov.ida.common.shared.security.PrivateKeyFactory();
+        return privateKeyFactory.createPrivateKey(privateKey);
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/PrivateKeyFileConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/PrivateKeyFileConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.PrivateKey;
+
+public class PrivateKeyFileConfiguration extends PrivateKeyFactory {
+
+    @JsonCreator
+    public PrivateKeyFileConfiguration(
+            @JsonProperty("key") @JsonAlias({ "file" }) String keyFile) {
+        try {
+            this.privateKey = getPrivateKeyFromBytes(Files.readAllBytes(Paths.get(keyFile)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PrivateKey privateKey;
+
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/TransparentPrivateKeyFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/TransparentPrivateKeyFactory.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.verifyserviceprovider.configuration;
+
+import java.security.PrivateKey;
+
+public class TransparentPrivateKeyFactory extends PrivateKeyFactory {
+
+    private PrivateKey aNull;
+
+    public TransparentPrivateKeyFactory(PrivateKey key) {
+        this.aNull = key;
+    }
+
+    @Override
+    public PrivateKey getPrivateKey() {
+        return aNull;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/VerifyServiceProviderConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.ida.verifyserviceprovider.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.Configuration;
 import io.dropwizard.validation.ValidationMethod;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
@@ -18,30 +17,49 @@ import java.security.PrivateKey;
 import java.util.List;
 import java.util.Optional;
 
+
 public class VerifyServiceProviderConfiguration extends Configuration {
 
     public static final String NOT_EMPTY_MESSAGE = "may not be empty";
+
+    @NotNull @Size(min = 1, message = NOT_EMPTY_MESSAGE) @Valid
     private List<String> serviceEntityIds;
+
+    @Valid
     private String hashingEntityId;
+
+    @NotNull @Valid
     private VerifyHubConfiguration verifyHubConfiguration;
-    private PrivateKey samlSigningKey;
-    private PrivateKey samlPrimaryEncryptionKey;
-    private PrivateKey samlSecondaryEncryptionKey;
+
+    @Valid @NotNull
+    private PrivateKeyFactory samlSigningKey;
+
+    @Valid @NotNull
+    private PrivateKeyFactory samlPrimaryEncryptionKey;
+
+    @Valid
+    private PrivateKeyFactory samlSecondaryEncryptionKey;
+
+    @Valid @UnwrapValidatedValue
     private Optional<MsaMetadataConfiguration> msaMetadata;
+
+    @NotNull @Valid
     private Duration clockSkew;
+
+    @Valid @UnwrapValidatedValue
     private Optional<EuropeanIdentityConfiguration> europeanIdentity;
 
     protected VerifyServiceProviderConfiguration() {}
     public VerifyServiceProviderConfiguration(
-        @JsonProperty("serviceEntityIds") @NotNull @Size(min = 1, message = NOT_EMPTY_MESSAGE) @Valid List<String> serviceEntityIds,
-        @JsonProperty("hashingEntityId") @Valid String hashingEntityId,
-        @JsonProperty("verifyHubConfiguration") @NotNull @Valid VerifyHubConfiguration verifyHubConfiguration,
-        @JsonProperty("samlSigningKey") @NotNull @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlSigningKey,
-        @JsonProperty("samlPrimaryEncryptionKey") @NotNull @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlPrimaryEncryptionKey,
-        @JsonProperty("samlSecondaryEncryptionKey") @Valid @JsonDeserialize(using = PrivateKeyDeserializer.class) PrivateKey samlSecondaryEncryptionKey,
-        @JsonProperty("msaMetadata") @NotNull @UnwrapValidatedValue @Valid Optional<MsaMetadataConfiguration> msaMetadata,
-        @JsonProperty("clockSkew") @NotNull @Valid Duration clockSkew,
-        @JsonProperty("europeanIdentity") @Valid @UnwrapValidatedValue Optional<EuropeanIdentityConfiguration> europeanIdentity
+        @JsonProperty("serviceEntityIds")List<String> serviceEntityIds,
+        @JsonProperty("hashingEntityId") String hashingEntityId,
+        @JsonProperty("verifyHubConfiguration") VerifyHubConfiguration verifyHubConfiguration,
+        @JsonProperty("samlSigningKey") PrivateKeyFactory samlSigningKey,
+        @JsonProperty("samlPrimaryEncryptionKey") PrivateKeyFactory samlPrimaryEncryptionKey,
+        @JsonProperty("samlSecondaryEncryptionKey") PrivateKeyFactory samlSecondaryEncryptionKey,
+        @JsonProperty("msaMetadata") Optional<MsaMetadataConfiguration> msaMetadata,
+        @JsonProperty("clockSkew") Duration clockSkew,
+        @JsonProperty("europeanIdentity") Optional<EuropeanIdentityConfiguration> europeanIdentity
     ) {
         this.serviceEntityIds = serviceEntityIds;
         this.hashingEntityId = hashingEntityId;
@@ -74,15 +92,15 @@ public class VerifyServiceProviderConfiguration extends Configuration {
     }
 
     public PrivateKey getSamlSigningKey() {
-        return samlSigningKey;
+        return samlSigningKey.getPrivateKey();
     }
 
     public PrivateKey getSamlPrimaryEncryptionKey() {
-        return samlPrimaryEncryptionKey;
+        return samlPrimaryEncryptionKey.getPrivateKey();
     }
 
     public PrivateKey getSamlSecondaryEncryptionKey() {
-        return samlSecondaryEncryptionKey;
+        return Optional.ofNullable(samlSecondaryEncryptionKey).map(PrivateKeyFactory::getPrivateKey).orElse(null);
     }
 
     public Optional<MetadataResolverConfiguration> getMsaMetadata() {


### PR DESCRIPTION
It's now possible to set the private keys used by the VSP using private
keys defined on the filesystem:

```
samlSigningKey:
  type: 'file'
  file: 'somewhere/on/the/filesystem.pk8'
```