### PR TITLE
BAU: Add Codacy test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,31 @@
 language: java
+
 env:
-  - VERIFY_USE_PUBLIC_BINARIES=true
-jdk:
-  - oraclejdk8
-  - openjdk8
-  - openjdk11
+  global:
+    - VERIFY_USE_PUBLIC_BINARIES=true
+    # GITHUB_PAT
+    - secure: "nCdMvwIX+lGcJEEyUoFkXz0eBQUXdlY2QqrL5aQA37L6TA78EWxzdawjYi/hIwqx9dfOXYSbZsWbHABfyghQyjKaoF6G+b+CSmq4CDYIpPZMtJNLjPraM7P/FfXu4ocgvKg/MIQoD/63c57ha1HFeoY3A2Zo08Ug2bSlF4/Sx3cnzJNoZNsk7RTUc7xIzfeHYZeVPfs6PxX4M450fwZeAtzq7ktNYfdbBnxMiUG55YTW/1Zkwhc82RKeCXDoq+ILQ+a4jEhgNql0Gzbw79zpvclDhNIxUUIml2UutIq8BOWbIf7Emo/3+tgR3K1GdCAvdFEqF8ussE87teLDZlBzuvwFtEW+Nas04m2WUdKttgvAL+WHTy3hyrw7mX8Z73kAOmmYA6CXp6mye+nIvbmluTRS2niKqJeE8qTENy1+GTHnMcwyMl5LSX0FtH9yAIN/X2L/QBCOuG0XANvuvv1nQsI+Tzbr0O2WHiE2QIUnnS8l5M9QTRHhDYflNRaXEjvoVm6yaqhBaVmiqR32OiDvS/ilYfeLsDN+AsnXRi5RIGYzzdMST1viLoyf+SxOn1ajHxjidOOU4nE6UifVVZoCBlBdn6Q2xMC69BfpBDyTO3U/PXO3lfzPUFIYjPg+JQvHfsUhqRK39DYJBl83YUlph6flAMLof6DB8E0wKYIjzVA="
+    # CODACY_PROJECT_TOKEN
+    - secure: "eIA7sQrjvTiAIIYVCXqB+PAOaoPy5Okm4Pi1SZ98uJsa2ZCFeSSyO6mostll8JDTmSfLwQRcIL1Wm/Pg7TbsqiMAal594CJylfuVG1LUO2r+MdPHDMn1z9Zzg9OcTZ7TRMD22W2KDBjRs8MYDISqoPUsT6ar85KimiyN/+wMkgkh29qMRzeGdmcXVMmBHyiSF5KrbjpeIsjlSu0/6XDTxTImTpatqNO3pm3fRpak0hAxvsZuhhQkEY/zf66+a/SGWXg+Ancdh75MwVZeDLvi1nnCi09A+fOPGWAwKZ+cBzeo7MsJJW/qWEa2FlydBTylMxNzgOk6VAiK6nOAXfNwHyV2e0FhM2Lm3Bc6WoWMtWz6Xa2ygIrzrmQHJzCfhUfFDMju4tOBEtp4pZK9dkQk+6denr8lbszxc3JzYYhW4vqZMjATmmhoi5/CxnqokbgUJ8fk9xrAAjsOC71iUhZxoPcJpSTLd0cQiQie+8zIZU4HRMufE2mHGrjFSKxCM+AQ35yMlK7Te45I9ObOnLGLBBTcyeRzA4gt+/lLYPSshMxm/e3uwaeXYhfbH9R16AwXLupHO81rc9lx5jq4vbTYbcYwg0K3/WopOmhcy/xwLTF3E9Wv/hUKGZcQcE4m6T16CksC6+4QgbwugygF/pYe2chWsNzKT/8eRxv++nYSyQw="
+
 matrix:
+  include:
+  - jdk: oraclejdk8
+  - jdk: openjdk8
+  - jdk: openjdk11
+    after_success:
+      - "./gradlew jacocoTestReport"
+      - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+before_install:
+  - sudo apt-get install jq
+  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
+
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Verify Service Provider
+[![Build Status](https://travis-ci.com/alphagov/verify-service-provider.svg?branch=master)](https://travis-ci.com/alphagov/verify-service-provider)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/accd9189851c4f1a9830105a0349c535)](https://www.codacy.com/app/alphagov/verify-service-provider?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=alphagov/verify-service-provider&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/accd9189851c4f1a9830105a0349c535)](https://www.codacy.com/app/alphagov/verify-service-provider?utm_source=github.com&utm_medium=referral&utm_content=alphagov/verify-service-provider&utm_campaign=Badge_Coverage)
 
-[![Build Status](https://travis-ci.org/alphagov/verify-service-provider.svg?branch=master)](https://travis-ci.org/alphagov/verify-service-provider)
+# Verify Service Provider
 
 The Verify Service Provider (VSP) generates and translates Security Assertion Markup Language (SAML) messages to and from the GOV.UK Verify Hub. SAML is an open standard for secure message exchange which GOV.UK Verify uses when handling information about identities.
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,17 @@ apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'idea'
 
+if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+    apply plugin: 'jacoco'
+
+    jacocoTestReport {
+        reports {
+            html.enabled = true
+            xml.enabled = true
+        }
+    }
+}
+
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')


### PR DESCRIPTION
Report test coverage to Codacy.

Only run the coverage report on JDK 9 and later as the plugin doesn't work Java 8.