### PR TITLE
[WIP] Prototype new API for generating OIDC requests and translating OIDC responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ project.ext {
 
 dependencies {
     compile(
+        "com.nimbusds:oauth2-oidc-sdk:6.14",
         "io.dropwizard:dropwizard-core:$dropwizardVersion",
         "io.dropwizard:dropwizard-json-logging:${dropwizardVersion}",
         "org.json:json:20171018",

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/VerifyServiceProviderApplication.java
@@ -17,6 +17,7 @@ import uk.gov.ida.verifyserviceprovider.exceptions.JerseyViolationExceptionMappe
 import uk.gov.ida.verifyserviceprovider.exceptions.JsonProcessingExceptionMapper;
 import uk.gov.ida.verifyserviceprovider.factories.VerifyServiceProviderFactory;
 import uk.gov.ida.verifyserviceprovider.listeners.VerifyServiceProviderServerListener;
+import uk.gov.ida.verifyserviceprovider.resources.OidcAuthenticationResource;
 import uk.gov.ida.verifyserviceprovider.utils.ConfigurationFileFinder;
 
 import javax.ws.rs.client.Client;
@@ -74,6 +75,7 @@ public class VerifyServiceProviderApplication extends Application<VerifyServiceP
         environment.jersey().register(factory.getVersionNumberResource());
         environment.jersey().register(factory.getGenerateAuthnRequestResource());
         environment.jersey().register(factory.getTranslateSamlResponseResource());
+        environment.jersey().register(new OidcAuthenticationResource());
         environment.lifecycle().addServerLifecycleListener(new VerifyServiceProviderServerListener(environment));
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/resources/OidcAuthenticationResource.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/resources/OidcAuthenticationResource.java
@@ -1,0 +1,85 @@
+package uk.gov.ida.verifyserviceprovider.resources;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationResponseParser;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import uk.gov.ida.verifyserviceprovider.services.OidcService;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/")
+public class OidcAuthenticationResource {
+    private final OidcService oidcService;
+
+    public OidcAuthenticationResource() {
+        this.oidcService = new OidcService();
+    }
+
+    @GET
+    @Path("/getAuthorizationCode")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAuthorizationCode() {
+        // TODO this VSP interface isn't right but this structure helps with testing for the moment. Will need to revisit.
+        return getAuthorizationCodeViaHttpRedirect();
+    }
+
+    @GET
+    @Path("/authenticationRequestCallback")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response authenticationRequestCallback(@Context UriInfo uriInfo) {
+        try {
+            AuthenticationResponse authenticationResponse = AuthenticationResponseParser.parse(uriInfo.getRequestUri());
+            if (authenticationResponse instanceof AuthenticationErrorResponse) {
+                ErrorObject error = authenticationResponse.toErrorResponse().getErrorObject();
+                // TODO handle exceptions
+            }
+
+            // TODO validate authentication response
+
+            AuthorizationCode authorizationCode = authenticationResponse.toSuccessResponse().getAuthorizationCode();
+            return Response.ok(authorizationCode).build();
+        } catch (ParseException e) {
+            //TODO handle exceptions
+            throw new RuntimeException(e);
+        }
+    }
+
+    @GET
+    @Path("/getClaims")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getClaims(@QueryParam("code") @NotNull AuthorizationCode authorizationCode) {
+        try {
+            OIDCTokens tokens = oidcService.getTokens(authorizationCode);
+            String idTokenSubject = tokens.getIDToken().getJWTClaimsSet().getSubject();
+
+            UserInfo userInfo = oidcService.getUserInfo(tokens.getBearerAccessToken());
+            String userInfoSubject = userInfo.getSubject().getValue();
+
+            // TODO design JSON response
+            return Response.ok(userInfoSubject).build();
+        } catch (java.text.ParseException e) {
+            // TODO handle exceptions
+            throw new RuntimeException();
+        }
+    }
+
+    private Response getAuthorizationCodeViaHttpRedirect() {
+        return Response
+                .status(302)
+                .location(oidcService.generateAuthenticationRequest().toURI())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/OidcService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/OidcService.java
@@ -1,0 +1,105 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class OidcService {
+    // TODO client registration so that these values are not hardcoded
+    private final String providerAuthenticationRequestUri = "http://localhost:50140/barclays/authorize";
+    private final String providerTokenRequestUri = "http://localhost:50140/barclays/token";
+    private final String providerUserInfoUri = "http://localhost:50140/barclays/userinfo";
+
+    private final String clientAuthenticationRequestRedirectUri = "http://localhost:50400/authenticationRequestCallback";
+    private final ClientID clientID = new ClientID("vsp");
+    private final Secret clientSecret = new Secret();
+
+    public OidcService() { }
+
+    public OIDCTokens getTokens(AuthorizationCode authorizationCode) {
+        TokenRequest tokenRequest = generateTokenRequest(authorizationCode);
+
+        try {
+            TokenResponse tokenResponse = OIDCTokenResponseParser.parse(tokenRequest.toHTTPRequest().send());
+
+            if (!tokenResponse.indicatesSuccess()) {
+                ErrorObject error = tokenResponse.toErrorResponse().getErrorObject();
+                // TODO handle exceptions
+                throw new RuntimeException();
+            }
+
+            // TODO validate token response
+
+            return tokenResponse.toSuccessResponse().getTokens().toOIDCTokens();
+        } catch (IOException | ParseException e) {
+            // TODO handle exceptions
+            throw new RuntimeException(e);
+        }
+    }
+
+    public UserInfo getUserInfo(BearerAccessToken accessToken) {
+        UserInfoRequest userInfoRequest = generateUserInfoRequest(accessToken);
+
+        try {
+            UserInfoResponse userInfoResponse = UserInfoResponse.parse(userInfoRequest.toHTTPRequest().send());
+
+            if (!userInfoResponse.indicatesSuccess()) {
+                ErrorObject error = userInfoResponse.toErrorResponse().getErrorObject();
+                // TODO handle exceptions
+                throw new RuntimeException();
+            }
+
+            // TODO validate userinfo response
+
+            return userInfoResponse.toSuccessResponse().getUserInfo();
+        } catch (IOException | ParseException e) {
+            // TODO handle exceptions
+            throw new RuntimeException(e);
+        }
+    }
+
+    public AuthenticationRequest generateAuthenticationRequest() {
+        // TODO what should these values be?
+        State state = new State();
+        Nonce nonce = new Nonce();
+        Scope scope = new Scope("openid");
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest(
+                URI.create(providerAuthenticationRequestUri),
+                new ResponseType(ResponseType.Value.CODE),
+                scope, clientID, URI.create(clientAuthenticationRequestRedirectUri), state, nonce);
+
+        return authenticationRequest;
+    }
+
+    private TokenRequest generateTokenRequest(AuthorizationCode authCode) {
+        return new TokenRequest(
+                URI.create(providerTokenRequestUri),
+                new ClientSecretBasic(clientID, clientSecret),
+                new AuthorizationCodeGrant(authCode, URI.create(clientAuthenticationRequestRedirectUri)));
+    }
+
+    private UserInfoRequest generateUserInfoRequest(BearerAccessToken accessToken) {
+        return new UserInfoRequest(URI.create(providerUserInfoUri), accessToken);
+    }
+}


### PR DESCRIPTION
The VSP has an API used by services to generate SAML requests from JSON and translate SAML responses to JSON. This is the start of a prototype that creates an API that generates OIDC requests from JSON and translates OIDC responses to JSON.

At the moment there are two new endpoints on the API. One generates an OIDC authentication request and returns an authorization code. The other takes the authorization code and uses it to retrieve claims from the token and userinfo endpoints. Currently it is hardcoded to talk to these endpoints on a locally running version of verify-stub-idp.

There are lots of holes in this prototype that require discovery and there will be changes made as we learn new things and make some decisions.