### PR TITLE
BAU: Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ project.ext {
     samlLibVersion = "$openSamlVersion-216"
     dropwizardVersion = '1.3.9'
     jaxbapiVersion = '2.2.9'
-    hub_saml="$openSamlVersion-15781"
-
 }
 
 dependencies {
@@ -49,8 +47,9 @@ dependencies {
         "org.opensaml:opensaml-core:$openSamlVersion",
         "org.opensaml:opensaml-saml-impl:$openSamlVersion",
         "uk.gov.ida:common-utils:$verifyCommonUtils",
+        "uk.gov.ida:dropwizard-logstash:$dropwizardVersion-71",
+        "uk.gov.ida:rest-utils:2.0.0-370",
         "uk.gov.ida:saml-lib:$samlLibVersion",
-        "uk.gov.ida:hub-saml:$hub_saml",
         "org.bouncycastle:bcprov-jdk15on:1.60",
         "org.bouncycastle:bcpkix-jdk15on:1.60",
         "javax.activation:javax.activation-api:1.2.0"
@@ -60,10 +59,9 @@ dependencies {
         'junit:junit:4.12',
         "io.dropwizard:dropwizard-testing:$dropwizardVersion",
         'org.mockito:mockito-core:2.24.5',
-        "uk.gov.ida:saml-lib:$samlLibVersion",
         "uk.gov.ida:common-test-utils:2.0.0-44",
         "org.jsoup:jsoup:1.11.1",
-        "uk.gov.ida:hub-saml-test-utils:$hub_saml",
+        "uk.gov.ida:saml-test:$samlLibVersion",
         "javax.activation:javax.activation-api:1.2.0",
     )
     testCompile('com.github.tomakehurst:wiremock:2.11.0'){ transitive = false }


### PR DESCRIPTION
We don't need to depend on `hub-saml`.

We should be using the unified `saml-lib` library rather than separate libs.