### PR TITLE
EID-1683 make hubConnectorEntityId optional

### DIFF
--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
@@ -52,9 +52,9 @@ public interface ConfigurationConstants {
     String[] INTEGRATION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS = new String[] {
         "https://www.integration.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
         "https://connector-node-integration.london.verify.govsvc.uk/ConnectorMetadata",         // (GSP)
-        "https://integration.eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
-        "https://connector.integration.eidas.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
-        "https://connector-node.integration.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
+        "https://eidas.integration.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
+        "https://connector.eidas.integration.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
+        "https://connector-node.eidas.integration.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
     String COMPLIANCE_SSO = COMPLIANCE_HOST + SSO_PATH;
@@ -66,9 +66,9 @@ public interface ConfigurationConstants {
     String[] COMPLIANCE_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS = new String[] {
         "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/metadata/connector",         // (AWS)
         "connector-node-compliance-tool-reference.london.verify.govsvc.uk/ConnectorMetadata",                   // (GSP)
-        "https://compliance-tool-reference.eidas.signin.service.gov.uk/ConnectorMetadata",                      // (potential new #1)
-        "https://connector.compliance-tool-reference.eidas.signin.service.gov.uk/ConnectorMetadata",            // (potential new #2)
-        "https://compliance-tool-reference-node.integration.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
+        "https://eidas.compliance-tool-reference.signin.service.gov.uk/ConnectorMetadata",                      // (potential new #1)
+        "https://connector.eidas.compliance-tool-reference.signin.service.gov.uk/ConnectorMetadata",            // (potential new #2)
+        "https://compliance-tool-reference-node.eidas.integration.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/ConfigurationConstants.java
@@ -27,13 +27,11 @@ public interface ConfigurationConstants {
     String METADATA_PATH = "/SAML2/metadata/federation";
     String TRUSTANCHOR_PATH = "/SAML2/metadata/trust-anchor";
     String METADATASOURCE_PATH = "/SAML2/metadata/aggregator";
-    String HUBCONNECTOR_ENTITY_ID_PATH = "/SAML2/metadata/connector";
 
     String PRODUCTION_SSO = PRODUCTION_HOST + SSO_PATH;
     String PRODUCTION_METADATA = PRODUCTION_HOST + METADATA_PATH;
     String PRODUCTION_TRUSTANCHOR_URI = PRODUCTION_HOST + TRUSTANCHOR_PATH;
     String PRODUCTION_METADATASOURCE_URI = PRODUCTION_HOST + METADATASOURCE_PATH;
-    String PRODUCTION_HUBCONNECTOR_ENTITY_ID = PRODUCTION_HOST + HUBCONNECTOR_ENTITY_ID_PATH;
 
     String[] PRODUCTION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS = new String[] {
         "https://www.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
@@ -47,7 +45,6 @@ public interface ConfigurationConstants {
     String INTEGRATION_METADATA = INTEGRATION_HOST +  METADATA_PATH;
     String INTEGRATION_TRUSTANCHOR_URI = INTEGRATION_HOST + TRUSTANCHOR_PATH;
     String INTEGRATION_METADATASOURCE_URI = INTEGRATION_HOST + METADATASOURCE_PATH;
-    String INTEGRATION_HUBCONNECTOR_ENTITY_ID = INTEGRATION_HOST + HUBCONNECTOR_ENTITY_ID_PATH;
 
     String[] INTEGRATION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS = new String[] {
         "https://www.integration.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
@@ -61,7 +58,6 @@ public interface ConfigurationConstants {
     String COMPLIANCE_METADATA = COMPLIANCE_HOST +  METADATA_PATH;
     String COMPLIANCE_TRUSTANCHOR_URI = COMPLIANCE_HOST +  TRUSTANCHOR_PATH;
     String COMPLIANCE_METADATASOURCE_URI = COMPLIANCE_HOST + METADATASOURCE_PATH;
-    String COMPLIANCE_HUBCONNECTOR_ENTITY_ID = COMPLIANCE_HOST + HUBCONNECTOR_ENTITY_ID_PATH;
 
     String[] COMPLIANCE_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS = new String[] {
         "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/metadata/connector",         // (AWS)

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -42,13 +42,9 @@ public class EuropeanIdentityConfiguration extends EidasMetadataConfiguration {
     ){
         super(trustAnchorUri, minRefreshDelay, maxRefreshDelay, trustAnchorMaxRefreshDelay, trustAnchorMinRefreshDelay, client, jerseyClientName, trustStore, metadataSourceUri);
         this.enabled = enabled;
-        this.hubConnectorEntityId = hubConnectorEntityId;
         this.trustStoreConfiguration = trustStore;
-
-        Set<String> hubConnectorEntityIds = new HashSet<>();
-        Optional.ofNullable(hubConnectorEntityId).ifPresent(hubConnectorEntityIds::add);
-        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(hubConnectorEntityIds::addAll);
-        this.acceptableHubConnectorEntityIds = new ArrayList<>(hubConnectorEntityIds);
+        this.hubConnectorEntityId = hubConnectorEntityId;
+        this.acceptableHubConnectorEntityIds = acceptableHubConnectorEntityIds;
     }
 
     @JsonIgnore
@@ -61,7 +57,7 @@ public class EuropeanIdentityConfiguration extends EidasMetadataConfiguration {
     }
 
     public List<String> getAllAcceptableHubConnectorEntityIds() {
-        Set<String> entityIds = new HashSet<>(environment.getEidasAllAcceptableHubConnectorEntityIds());
+        Set<String> entityIds = new HashSet<>(environment.getEidasDefaultAcceptableHubConnectorEntityIds());
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         return new ArrayList<>(entityIds);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfiguration.java
@@ -46,8 +46,8 @@ public class EuropeanIdentityConfiguration extends EidasMetadataConfiguration {
         this.trustStoreConfiguration = trustStore;
 
         Set<String> hubConnectorEntityIds = new HashSet<>();
-        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(hubConnectorEntityIds::addAll);
         Optional.ofNullable(hubConnectorEntityId).ifPresent(hubConnectorEntityIds::add);
+        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(hubConnectorEntityIds::addAll);
         this.acceptableHubConnectorEntityIds = new ArrayList<>(hubConnectorEntityIds);
     }
 
@@ -60,14 +60,11 @@ public class EuropeanIdentityConfiguration extends EidasMetadataConfiguration {
         return enabled;
     }
 
-    public String getHubConnectorEntityId() {
-        return Optional.ofNullable(hubConnectorEntityId)
-                .orElse(environment.getEidasHubConnectorEntityId());
-    }
-
-    public List<String> getAcceptableHubConnectorEntityIds() {
-        return Optional.ofNullable(acceptableHubConnectorEntityIds)
-            .orElse(environment.getEidasAcceptableHubConnectorEntityIds());
+    public List<String> getAllAcceptableHubConnectorEntityIds() {
+        Set<String> entityIds = new HashSet<>(environment.getEidasAllAcceptableHubConnectorEntityIds());
+        Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
+        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
+        return new ArrayList<>(entityIds);
     }
 
     @Override

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
@@ -73,7 +73,6 @@ public enum HubEnvironment {
 
     private URI eidasMetaDataSourceUri;
     private URI eidasMetadataTrustAnchorUri;
-    private String eidasHubConnectorEntityId;
     private List<String> eidasAcceptableHubConnectorEntityIds;
     private String metadataTrustStore;
     private String hubTrustStore;
@@ -95,14 +94,13 @@ public enum HubEnvironment {
         this.metadataUri = metadataUri;
         this.eidasMetaDataSourceUri = eidasMetadataSourceUri;
         this.eidasMetadataTrustAnchorUri = eidasMetadataTrustAnchorUri;
-        this.eidasHubConnectorEntityId = eidasHubConnectorEntityId;
         this.metadataTrustStore = metadataTrustStore;
         this.hubTrustStore = hubTrustStore;
         this.idpTrustStore = idpTrustStore;
 
         Set<String> entityIds = new HashSet<>();
-        Optional.ofNullable(eidasAcceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         Optional.ofNullable(eidasHubConnectorEntityId).ifPresent(entityIds::add);
+        Optional.ofNullable(eidasAcceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         this.eidasAcceptableHubConnectorEntityIds = new ArrayList<>(entityIds);
     }
 
@@ -122,11 +120,7 @@ public enum HubEnvironment {
         return this.eidasMetadataTrustAnchorUri;
     }
 
-    public String getEidasHubConnectorEntityId(){
-        return this.eidasHubConnectorEntityId;
-    }
-
-    public List<String> getEidasAcceptableHubConnectorEntityIds() {
+    public List<String> getEidasAllAcceptableHubConnectorEntityIds() {
         return this.eidasAcceptableHubConnectorEntityIds;
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/configuration/HubEnvironment.java
@@ -10,27 +10,21 @@ import java.net.URI;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS;
-import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_HUBCONNECTOR_ENTITY_ID;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_METADATA;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_METADATASOURCE_URI;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_SSO;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.COMPLIANCE_TRUSTANCHOR_URI;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.DEFAULT_TRUST_STORE_PASSWORD;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS;
-import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_HUBCONNECTOR_ENTITY_ID;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_METADATA;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_METADATASOURCE_URI;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_SSO;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.INTEGRATION_TRUSTANCHOR_URI;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS;
-import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_HUBCONNECTOR_ENTITY_ID;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_HUB_TRUSTSTORE;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_IDP_TRUSTSTORE;
 import static uk.gov.ida.verifyserviceprovider.configuration.ConfigurationConstants.PRODUCTION_METADATA;
@@ -48,7 +42,6 @@ public enum HubEnvironment {
             URI.create(PRODUCTION_METADATA),
             URI.create(PRODUCTION_METADATASOURCE_URI),
             URI.create(PRODUCTION_TRUSTANCHOR_URI),
-            PRODUCTION_HUBCONNECTOR_ENTITY_ID,
             asList(PRODUCTION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS),
             PRODUCTION_METADATA_TRUSTSTORE, PRODUCTION_HUB_TRUSTSTORE, PRODUCTION_IDP_TRUSTSTORE),
     INTEGRATION(
@@ -56,7 +49,6 @@ public enum HubEnvironment {
             URI.create(INTEGRATION_METADATA),
             URI.create(INTEGRATION_METADATASOURCE_URI),
             URI.create(INTEGRATION_TRUSTANCHOR_URI),
-            INTEGRATION_HUBCONNECTOR_ENTITY_ID,
             asList(INTEGRATION_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS),
             TEST_METADATA_TRUSTSTORE, TEST_HUB_TRUSTSTORE, TEST_IDP_TRUSTSTORE),
     COMPLIANCE_TOOL(
@@ -64,7 +56,6 @@ public enum HubEnvironment {
             URI.create(COMPLIANCE_METADATA),
             URI.create(COMPLIANCE_METADATASOURCE_URI),
             URI.create(COMPLIANCE_TRUSTANCHOR_URI),
-            COMPLIANCE_HUBCONNECTOR_ENTITY_ID,
             asList(COMPLIANCE_ACCEPTABLE_HUBCONNECTOR_ENTITY_IDS),
             TEST_METADATA_TRUSTSTORE, TEST_HUB_TRUSTSTORE, TEST_IDP_TRUSTSTORE);
 
@@ -73,7 +64,7 @@ public enum HubEnvironment {
 
     private URI eidasMetaDataSourceUri;
     private URI eidasMetadataTrustAnchorUri;
-    private List<String> eidasAcceptableHubConnectorEntityIds;
+    private List<String> eidasDefaultAcceptableHubConnectorEntityIds;
     private String metadataTrustStore;
     private String hubTrustStore;
     private String idpTrustStore;
@@ -89,7 +80,7 @@ public enum HubEnvironment {
             ));
     }
 
-    HubEnvironment(URI ssoLocation, URI metadataUri, URI eidasMetadataSourceUri, URI eidasMetadataTrustAnchorUri, String eidasHubConnectorEntityId, List<String> eidasAcceptableHubConnectorEntityIds, String metadataTrustStore, String hubTrustStore, String idpTrustStore) {
+    HubEnvironment(URI ssoLocation, URI metadataUri, URI eidasMetadataSourceUri, URI eidasMetadataTrustAnchorUri, List<String> eidasDefaultAcceptableHubConnectorEntityIds, String metadataTrustStore, String hubTrustStore, String idpTrustStore) {
         this.ssoLocation = ssoLocation;
         this.metadataUri = metadataUri;
         this.eidasMetaDataSourceUri = eidasMetadataSourceUri;
@@ -98,10 +89,7 @@ public enum HubEnvironment {
         this.hubTrustStore = hubTrustStore;
         this.idpTrustStore = idpTrustStore;
 
-        Set<String> entityIds = new HashSet<>();
-        Optional.ofNullable(eidasHubConnectorEntityId).ifPresent(entityIds::add);
-        Optional.ofNullable(eidasAcceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
-        this.eidasAcceptableHubConnectorEntityIds = new ArrayList<>(entityIds);
+        this.eidasDefaultAcceptableHubConnectorEntityIds = new ArrayList<>(eidasDefaultAcceptableHubConnectorEntityIds);
     }
 
     public URI getSsoLocation() {
@@ -120,8 +108,8 @@ public enum HubEnvironment {
         return this.eidasMetadataTrustAnchorUri;
     }
 
-    public List<String> getEidasAllAcceptableHubConnectorEntityIds() {
-        return this.eidasAcceptableHubConnectorEntityIds;
+    public List<String> getEidasDefaultAcceptableHubConnectorEntityIds() {
+        return this.eidasDefaultAcceptableHubConnectorEntityIds;
     }
 
     public KeyStore getMetadataTrustStore() {

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -180,8 +180,7 @@ public class ResponseFactory {
                 new LevelOfAssuranceValidator(),
                 eidasMetadataResolverRepository,
                 new SignatureValidatorFactory(),
-                europeanIdentityConfiguration.getHubConnectorEntityId(),
-                europeanIdentityConfiguration.getAcceptableHubConnectorEntityIds(),
+                europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds(),
                 new UserIdHashFactory(hashingEntityId)
                 );
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
@@ -31,7 +31,6 @@ public class EidasAssertionTranslator extends IdentityAssertionTranslator {
     private final LevelOfAssuranceValidator levelOfAssuranceValidator;
     private final EidasMetadataResolverRepository metadataResolverRepository;
     private final SignatureValidatorFactory signatureValidatorFactory;
-    private final String hubConnectorEntityId;
     private final List<String> acceptableHubConnectorEntityIds;
     private UserIdHashFactory userIdHashFactory;
     private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
@@ -45,7 +44,6 @@ public class EidasAssertionTranslator extends IdentityAssertionTranslator {
             LevelOfAssuranceValidator levelOfAssuranceValidator,
             EidasMetadataResolverRepository metadataResolverRepository,
             SignatureValidatorFactory signatureValidatorFactory,
-            String hubConnectorEntityId,
             List<String> acceptableHubConnectorEntityIds,
             UserIdHashFactory userIdHashFactory) {
         super(subjectValidator, matchingDatasetUnmarshaller, mdsMapper);
@@ -54,7 +52,6 @@ public class EidasAssertionTranslator extends IdentityAssertionTranslator {
         this.levelOfAssuranceValidator = levelOfAssuranceValidator;
         this.metadataResolverRepository = metadataResolverRepository;
         this.signatureValidatorFactory = signatureValidatorFactory;
-        this.hubConnectorEntityId = hubConnectorEntityId;
         this.acceptableHubConnectorEntityIds = acceptableHubConnectorEntityIds;
         this.userIdHashFactory = userIdHashFactory;
     }

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -67,7 +67,7 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(30));
         assertThat(configuration.getEuropeanIdentity().isPresent()).isTrue();
-        assertThat(configuration.getEuropeanIdentity().get().getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.COMPLIANCE_TOOL.getEidasAllAcceptableHubConnectorEntityIds());
+        assertThat(configuration.getEuropeanIdentity().get().getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.COMPLIANCE_TOOL.getEidasDefaultAcceptableHubConnectorEntityIds());
         assertThat(configuration.getEuropeanIdentity().get().getMetadataSourceUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataSourceUri());
         assertThat(configuration.getEuropeanIdentity().get().getTrustAnchorUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataTrustAnchorUri());
         assertThat(configuration.getEuropeanIdentity().get().getTrustStore().getCertificate("idaca").toString())

--- a/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
+++ b/src/test/java/feature/uk/gov/ida/verifyserviceprovider/configuration/ApplicationConfigurationFeatureTests.java
@@ -67,7 +67,7 @@ public class ApplicationConfigurationFeatureTests {
         assertThat(configuration.getSamlSecondaryEncryptionKey().getEncoded()).isEqualTo(decode(TEST_RP_PRIVATE_ENCRYPTION_KEY));
         assertThat(configuration.getClockSkew()).isEqualTo(Duration.standardSeconds(30));
         assertThat(configuration.getEuropeanIdentity().isPresent()).isTrue();
-        assertThat(configuration.getEuropeanIdentity().get().getHubConnectorEntityId()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasHubConnectorEntityId());
+        assertThat(configuration.getEuropeanIdentity().get().getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.COMPLIANCE_TOOL.getEidasAllAcceptableHubConnectorEntityIds());
         assertThat(configuration.getEuropeanIdentity().get().getMetadataSourceUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataSourceUri());
         assertThat(configuration.getEuropeanIdentity().get().getTrustAnchorUri()).isEqualTo(HubEnvironment.COMPLIANCE_TOOL.getEidasMetadataTrustAnchorUri());
         assertThat(configuration.getEuropeanIdentity().get().getTrustStore().getCertificate("idaca").toString())

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -100,7 +100,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getHubConnectorEntityId().toString()).isEqualTo(overriddenHubConnectorEntityId);
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds().toString()).contains(overriddenHubConnectorEntityId);
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
     }
@@ -119,7 +119,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getHubConnectorEntityId()).isEqualTo(HubEnvironment.INTEGRATION.getEidasHubConnectorEntityId());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri().toString()).isEqualTo(overriddenTrustAnchorUri);
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
     }
@@ -138,7 +138,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isNotEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getHubConnectorEntityId()).isEqualTo(HubEnvironment.INTEGRATION.getEidasHubConnectorEntityId());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
     }
@@ -157,7 +157,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getHubConnectorEntityId()).isEqualTo(HubEnvironment.INTEGRATION.getEidasHubConnectorEntityId());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overriddenMetadataSourceUri);
 
@@ -208,7 +208,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(productionEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getHubConnectorEntityId()).isEqualTo(HubEnvironment.PRODUCTION.getEidasHubConnectorEntityId());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.PRODUCTION.getEidasAllAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.PRODUCTION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overriddenMetadataSourceUri);
     }

--- a/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/verifyserviceprovider/configuration/EuropeanIdentityConfigurationTest.java
@@ -119,7 +119,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasDefaultAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri().toString()).isEqualTo(overriddenTrustAnchorUri);
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
     }
@@ -138,7 +138,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isNotEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasDefaultAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataSourceUri());
     }
@@ -157,7 +157,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(integrationEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasAllAcceptableHubConnectorEntityIds());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.INTEGRATION.getEidasDefaultAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.INTEGRATION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overriddenMetadataSourceUri);
 
@@ -208,7 +208,7 @@ public class EuropeanIdentityConfigurationTest {
         assertThat(europeanIdentityConfiguration.getTrustStore().size()).isEqualTo(2);
         assertThat(europeanConfigCert).isEqualTo(productionEntryCert);
 
-        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.PRODUCTION.getEidasAllAcceptableHubConnectorEntityIds());
+        assertThat(europeanIdentityConfiguration.getAllAcceptableHubConnectorEntityIds()).containsAll(HubEnvironment.PRODUCTION.getEidasDefaultAcceptableHubConnectorEntityIds());
         assertThat(europeanIdentityConfiguration.getTrustAnchorUri()).isEqualTo(HubEnvironment.PRODUCTION.getEidasMetadataTrustAnchorUri());
         assertThat(europeanIdentityConfiguration.getMetadataSourceUri().toString()).isEqualTo(overriddenMetadataSourceUri);
     }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslatorTest.java
@@ -97,7 +97,6 @@ public class EidasAssertionTranslatorTest {
             levelOfAssuranceValidator,
             metadataResolverRepository,
             signatureValidatorFactory,
-            HUB_CONNECTOR_ENTITY_ID,
             singletonList(HUB_CONNECTOR_ENTITY_ID),
             userIdHashFactory);
         doNothing().when(instantValidator).validate(any(), any());


### PR DESCRIPTION
This PR:

- ... makes the `hubConnectorEntityId` configuration option nullable.
- ... updates the subdomain ordering in the potential new entityIds.
- ... removes `getHubConnectorId()` in favour of `getAllAcceptableHubConnectorIds()`.
