### PR TITLE
EID-1607 Handle unsigned assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ project.ext {
     version_number = '2.0.0'
     openSamlVersion = '3.4.3'
     verifyCommonUtils = '2.0.0-337'
-    samlLibVersion = "$openSamlVersion-221"
+    samlLibVersion = "$openSamlVersion-224"
     dropwizardVersion = '1.3.9'
     jaxbapiVersion = '2.2.9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ project.ext {
     version_number = '2.0.0'
     openSamlVersion = '3.4.3'
     verifyCommonUtils = '2.0.0-337'
-    samlLibVersion = "$openSamlVersion-219"
+    samlLibVersion = "$openSamlVersion-221"
     dropwizardVersion = '1.3.9'
     jaxbapiVersion = '2.2.9'
 }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/NonMatchingEidasAcceptanceTest.java
@@ -131,19 +131,18 @@ public class NonMatchingEidasAcceptanceTest {
         org.opensaml.saml.saml2.core.Response countryResponse = anEidasResponseIssuedByACountryWithUnsignedAssertions("requestId", appWithEidasEnabled.getCountryEntityId()).build();
         org.opensaml.saml.saml2.core.Response hubResponse = aHubResponseContainingEidasUnsignedAssertions(
                 "requestId",
-                appWithEidasEnabled.getCountryEntityId(),
                 xmlToB64Transformer.apply(countryResponse),
                 getReEncryptedKeys(countryResponse)
         ).build();
 
-        Response appResonse = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
+        Response appResponse = appWithEidasEnabled.client().target(format("http://localhost:%s/translate-response", appWithEidasEnabled.getLocalPort())).request().post(
                 Entity.json(new TranslateSamlResponseBody(xmlToB64Transformer.apply(hubResponse), "requestId", LEVEL_2, null))
         );
 
-        String body = appResonse.readEntity(String.class);
+        String body = appResponse.readEntity(String.class);
         JSONObject json = new JSONObject(body);
 
-        assertThat(appResonse.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(appResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThat(json.getString("pid")).isEqualTo("428eb6096580250e9edbac60566529c2e8f9dbfe9ea88999b8996f6dbc602160");
     }
 

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
@@ -232,7 +232,6 @@ public class AssertionHelper {
 
     public static ResponseBuilder aHubResponseContainingEidasUnsignedAssertions(
             String requestId,
-            String assertionIssuerId,
             String countrySamlResponseString,
             List<String> encryptedKeys
     ) {
@@ -243,8 +242,8 @@ public class AssertionHelper {
                 .addEncryptedAssertion(
                         anEidasEncryptedAssertion(
                                 requestId,
-                                assertionIssuerId,
-                                anEidasSignature(),
+                                HUB_ENTITY_ID,
+                                aHubSignature(),
                                 anAttributeStatementContainingAnEidasUnsignedResponse(
                                         countrySamlResponseString,
                                         encryptedKeys
@@ -299,6 +298,16 @@ public class AssertionHelper {
                         new TestCredentialFactory(
                                 STUB_IDP_PUBLIC_PRIMARY_CERT,
                                 STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential()
+                ).build();
+    }
+
+    public static Signature aHubSignature() {
+        return aSignature()
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                HUB_TEST_PUBLIC_SIGNING_CERT,
+                                HUB_TEST_PRIVATE_SIGNING_KEY
                         ).getSigningCredential()
                 ).build();
     }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/AssertionHelper.java
@@ -1,20 +1,54 @@
 package uk.gov.ida.verifyserviceprovider.builders;
 
+import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
 import org.opensaml.saml.saml2.core.Audience;
 import org.opensaml.saml.saml2.core.AudienceRestriction;
 import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.impl.AudienceBuilder;
 import org.opensaml.saml.saml2.core.impl.AudienceRestrictionBuilder;
 import org.opensaml.saml.saml2.core.impl.ConditionsBuilder;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CountrySamlResponseBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.EncryptedAssertionKeysBuilder;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
 import uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder;
 import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.DecrypterFactory;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
+import uk.gov.ida.saml.security.SecretKeyEncrypter;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
 
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
@@ -32,6 +66,7 @@ import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.TEST_RP;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
 import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anEidasAuthnStatement;
 import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
@@ -47,11 +82,41 @@ public class AssertionHelper {
         return anEidasEncryptedAssertion(requestId, issuerId, assertionSignature, anEidasAttributeStatement().build());
     }
 
+    public static EncryptedAssertion anUnsignedEidasEncryptedAssertion(String requestId,
+                                                                       String issuerId,
+                                                                       Signature assertionSignature) {
+        return anEidasEncryptedAssertion(
+                requestId,
+                issuerId,
+                assertionSignature,
+                anEidasAttributeStatement().build(),
+                false,
+                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM
+        );
+    };
+
     public static EncryptedAssertion anEidasEncryptedAssertion(String requestId,
                                                                String issuerId,
                                                                Signature assertionSignature,
                                                                AttributeStatement attributeStatement) {
-        return anAssertion()
+        return anEidasEncryptedAssertion(
+                requestId,
+                issuerId,
+                assertionSignature,
+                attributeStatement,
+                true,
+                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128
+        );
+    }
+
+    public static EncryptedAssertion anEidasEncryptedAssertion(String requestId,
+                                                               String issuerId,
+                                                               Signature assertionSignature,
+                                                               AttributeStatement attributeStatement,
+                                                               boolean shouldSign,
+                                                               String encryptionAlgorithm)
+    {
+        AssertionBuilder assertionBuilder = anAssertion()
                 .withSubject(
                         aSubject().withSubjectConfirmation(
                                 aSubjectConfirmation().withSubjectConfirmationData(
@@ -66,14 +131,22 @@ public class AssertionHelper {
                                 .build())
                 .addAttributeStatement(attributeStatement)
                 .addAuthnStatement(anEidasAuthnStatement().build())
-                .withSignature(assertionSignature)
-                .withConditions(aConditionsForEidas())
-                .buildWithEncrypterCredential(
-                        new TestCredentialFactory(
-                                TEST_RP_PUBLIC_ENCRYPTION_CERT,
-                                TEST_RP_PRIVATE_ENCRYPTION_KEY
-                        ).getEncryptingCredential()
-                );
+                .withConditions(aConditionsForEidas());
+
+        if (shouldSign) {
+            assertionBuilder.withSignature(assertionSignature);
+        } else {
+            assertionBuilder.withoutSigning();
+            assertionBuilder.withSignature(null);
+        }
+
+        return assertionBuilder.buildWithEncrypterCredential(
+                new TestCredentialFactory(
+                        TEST_RP_PUBLIC_ENCRYPTION_CERT,
+                        TEST_RP_PRIVATE_ENCRYPTION_KEY
+                ).getEncryptingCredential(),
+                encryptionAlgorithm
+        );
     }
 
 
@@ -141,6 +214,46 @@ public class AssertionHelper {
                         new TestCredentialFactory(
                                 STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
                                 STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential());
+    }
+
+    public static ResponseBuilder anEidasResponseIssuedByACountryWithUnsignedAssertions(String requestId, String assertionIssuerId) {
+        return ResponseBuilder.aResponse()
+                .withId(requestId)
+                .withIssuer(anIssuer().withIssuerId(COUNTRY_ENTITY_ID).build())
+                .withInResponseTo(requestId)
+                .addEncryptedAssertion(anUnsignedEidasEncryptedAssertion(requestId, assertionIssuerId, anEidasSignature()))
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
+                                STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY
+                        ).getSigningCredential());
+    }
+
+    public static ResponseBuilder aHubResponseContainingEidasUnsignedAssertions(
+            String requestId,
+            String assertionIssuerId,
+            String countrySamlResponseString,
+            List<String> encryptedKeys
+    ) {
+        return ResponseBuilder.aResponse()
+                .withId(requestId)
+                .withInResponseTo(requestId)
+                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                .addEncryptedAssertion(
+                        anEidasEncryptedAssertion(
+                                requestId,
+                                assertionIssuerId,
+                                anEidasSignature(),
+                                anAttributeStatementContainingAnEidasUnsignedResponse(
+                                        countrySamlResponseString,
+                                        encryptedKeys
+                                )
+                        ))
+                .withSigningCredential(
+                        new TestCredentialFactory(
+                                HUB_TEST_PUBLIC_SIGNING_CERT,
+                                HUB_TEST_PRIVATE_SIGNING_KEY
                         ).getSigningCredential());
     }
 
@@ -231,5 +344,61 @@ public class AssertionHelper {
         audienceRestriction.getAudiences().add(audience);
         conditions.getAudienceRestrictions().add(audienceRestriction);
         return conditions;
+    }
+
+    private static AttributeStatement anAttributeStatementContainingAnEidasUnsignedResponse(String countrySamlResponseValue, List<String> encryptedKeys) {
+        CountrySamlResponse countrySamlAttributeValue = new CountrySamlResponseBuilder().buildObject();
+        countrySamlAttributeValue.setValue(countrySamlResponseValue);
+
+        Attribute countrySamlAttribute = (Attribute) XMLObjectSupport.buildXMLObject(Attribute.DEFAULT_ELEMENT_NAME);
+        countrySamlAttribute.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+        countrySamlAttribute.setFriendlyName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.FRIENDLY_NAME);
+        countrySamlAttribute.setNameFormat(Attribute.URI_REFERENCE);
+
+        countrySamlAttribute.getAttributeValues().add(countrySamlAttributeValue);
+
+        List<EncryptedAssertionKeys> assertionKeysValues = new ArrayList<>();
+        for (String key : encryptedKeys) {
+            EncryptedAssertionKeys keysAttribtueValue = new EncryptedAssertionKeysBuilder().buildObject();
+            keysAttribtueValue.setValue(key);
+            assertionKeysValues.add(keysAttribtueValue);
+        }
+
+        Attribute keysAttribute = (Attribute) XMLObjectSupport.buildXMLObject(Attribute.DEFAULT_ELEMENT_NAME);
+        keysAttribute.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+        keysAttribute.setFriendlyName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.FRIENDLY_NAME);
+        keysAttribute.setNameFormat(Attribute.URI_REFERENCE);
+
+        keysAttribute.getAttributeValues().addAll(assertionKeysValues);
+
+        return anAttributeStatement()
+                .addAttribute(countrySamlAttribute)
+                .addAttribute(keysAttribute)
+                .build();
+    }
+
+    public static List<String> getReEncryptedKeys(Response countryResponse) {
+        PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+        PrivateKey privateKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TestCertificateStrings.PRIVATE_SIGNING_KEYS.get(TEST_RP)));
+        PublicKey publicKey = publicKeyFactory.createPublicKey(TestCertificateStrings.getPrimaryPublicEncryptionCert(TEST_RP));
+
+        PrivateKey privateEncryptionKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TEST_RP_PRIVATE_ENCRYPTION_KEY));
+        PublicKey publicEncryptionKey = publicKeyFactory.createPublicKey(TEST_RP_PUBLIC_ENCRYPTION_CERT);
+
+        KeyPair encryptionKeyPair = new KeyPair(publicEncryptionKey, privateEncryptionKey);
+
+        IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(
+                new IdaKeyStore(new KeyPair(publicKey, privateKey), Arrays.asList(encryptionKeyPair))
+        );
+        List<Credential> credentials = keyStoreCredentialRetriever.getDecryptingCredentials();
+        Decrypter decrypter = new DecrypterFactory().createDecrypter(credentials);
+        AssertionDecrypter assertionDecrypter = new AssertionDecrypter(new EncryptionAlgorithmValidator(), decrypter);
+
+        KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
+        Credential credential = new TestCredentialFactory(TEST_RP_PUBLIC_ENCRYPTION_CERT, null).getEncryptingCredential();
+        when(credentialResolver.getEncryptingCredential(TEST_RP)).thenReturn(credential);
+        SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
+
+        return assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(countryResponse), secretKeyEncrypter, TEST_RP);
     }
 }

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolV2InitialisationRequestBuilder.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/builders/ComplianceToolV2InitialisationRequestBuilder.java
@@ -1,17 +1,11 @@
 package uk.gov.ida.verifyserviceprovider.builders;
 
-import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAddress;
-import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingAttribute;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDataset;
 import uk.gov.ida.verifyserviceprovider.compliance.dto.MatchingDatasetBuilder;
 
 import javax.ws.rs.client.Entity;
-import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.UUID;
 
-import static java.util.Collections.singletonList;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/MissingUnsignedAssertionsHandlerException.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/exceptions/MissingUnsignedAssertionsHandlerException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.verifyserviceprovider.exceptions;
+
+public class MissingUnsignedAssertionsHandlerException extends RuntimeException {
+    public MissingUnsignedAssertionsHandlerException() {
+        super("UnsignedAssertionsHandler missing: UnsignedAssertionsHandler can not be null in eIDAS enabled VSP");
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -178,7 +178,7 @@ public class VerifyServiceProviderFactory {
                         getHubSignatureTrustEngine(),
                         assertionTranslator,
                         dateTimeComparator,
-                        Optional.of(unsignedAssertionsResponseHandler)
+                        unsignedAssertionsResponseHandler
                 ),
                 entityIdService);
     }
@@ -195,7 +195,7 @@ public class VerifyServiceProviderFactory {
                         getHubSignatureTrustEngine(),
                         assertionTranslator,
                         dateTimeComparator,
-                        Optional.empty()
+                        null
                 ),
                 entityIdService);
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -130,14 +130,14 @@ public class VerifyServiceProviderFactory {
     private TranslateSamlResponseResource getTranslateMatchingSamlResponseResource() {
         ResponseService matchingResponseService = responseFactory.createMatchingResponseService(
                 getHubSignatureTrustEngine(),
-                responseFactory.createMsaAssertionService(getMsaSignatureTrustEngine(), new SignatureValidatorFactory(), dateTimeComparator),
+                responseFactory.createMsaAssertionTranslator(getMsaSignatureTrustEngine(), new SignatureValidatorFactory(), dateTimeComparator),
                 dateTimeComparator
         );
         return new TranslateSamlResponseResource(matchingResponseService, entityIdService);
     }
 
     private TranslateSamlResponseResource getEidasEnabledTranslateNonMatchingSamlResponseResource() {
-        VerifyAssertionTranslator verifyAssertionService = responseFactory.createVerifyIdpAssertionService(
+        VerifyAssertionTranslator verifyAssertionTranslator = responseFactory.createVerifyIdpAssertionTranslator(
                 hubSignatureValidator,
                 dateTimeComparator,
                 configuration.getHashingEntityId()
@@ -154,14 +154,14 @@ public class VerifyServiceProviderFactory {
                 hubSignatureValidator
         );
 
-        EidasAssertionTranslator eidasAssertionService = responseFactory.createEidasAssertionService(
+        EidasAssertionTranslator eidasAssertionTranslator = responseFactory.createEidasAssertionTranslator(
                 dateTimeComparator,
                 eidasMetadataResolverRepository,
                 configuration.getEuropeanIdentity().get(),
                 configuration.getHashingEntityId()
         );
 
-        EidasUnsignedAssertionTranslator eidasUnsignedAssertionService = responseFactory.createEidasUnsignedAssertionService(
+        EidasUnsignedAssertionTranslator eidasUnsignedAssertionTranslator = responseFactory.createEidasUnsignedAssertionTranslator(
                 dateTimeComparator,
                 eidasMetadataResolverRepository,
                 configuration.getEuropeanIdentity().get(),
@@ -169,9 +169,9 @@ public class VerifyServiceProviderFactory {
         );
 
         AssertionTranslator assertionTranslator = new ClassifyingAssertionTranslator(
-                verifyAssertionService,
-                eidasAssertionService,
-                eidasUnsignedAssertionService);
+                verifyAssertionTranslator,
+                eidasAssertionTranslator,
+                eidasUnsignedAssertionTranslator);
 
         return new TranslateSamlResponseResource(
                 responseFactory.createNonMatchingResponseService(
@@ -184,7 +184,7 @@ public class VerifyServiceProviderFactory {
     }
 
     private TranslateSamlResponseResource getTranslateNonMatchingSamlResponseResource() {
-        VerifyAssertionTranslator assertionTranslator = responseFactory.createVerifyIdpAssertionService(
+        VerifyAssertionTranslator assertionTranslator = responseFactory.createVerifyIdpAssertionTranslator(
                 hubSignatureValidator,
                 dateTimeComparator,
                 configuration.getHashingEntityId()

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -47,7 +47,7 @@ import java.util.Timer;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory.createStringToResponseTransformer;
-import static uk.gov.ida.verifyserviceprovider.validators.EidasEncryptionAlgorithmValidator.anEidasEncryptionAlgorithmValidator;
+import static uk.gov.ida.verifyserviceprovider.validators.EidasEncryptionAlgorithmValidatorHelper.anEidasEncryptionAlgorithmValidator;
 
 public class VerifyServiceProviderFactory {
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/VerifyServiceProviderFactory.java
@@ -12,7 +12,10 @@ import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.security.EidasValidatorFactory;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
 import uk.gov.ida.saml.security.MetadataBackedEncryptionCredentialResolver;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
 import uk.gov.ida.shared.utils.manifest.ManifestReader;
 import uk.gov.ida.verifyserviceprovider.configuration.EuropeanIdentityConfiguration;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
@@ -25,10 +28,13 @@ import uk.gov.ida.verifyserviceprovider.resources.VersionNumberResource;
 import uk.gov.ida.verifyserviceprovider.services.AssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.ClassifyingAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.EidasAssertionTranslator;
+import uk.gov.ida.verifyserviceprovider.services.EidasUnsignedAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
 import uk.gov.ida.verifyserviceprovider.services.ResponseService;
+import uk.gov.ida.verifyserviceprovider.services.UnsignedAssertionsResponseHandler;
 import uk.gov.ida.verifyserviceprovider.services.VerifyAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
 
 import javax.ws.rs.client.Client;
 import java.security.KeyException;
@@ -40,6 +46,8 @@ import java.util.Timer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory.createStringToResponseTransformer;
+import static uk.gov.ida.verifyserviceprovider.validators.EidasEncryptionAlgorithmValidator.anEidasEncryptionAlgorithmValidator;
 
 public class VerifyServiceProviderFactory {
 
@@ -52,6 +60,7 @@ public class VerifyServiceProviderFactory {
     private final MetadataResolverBundle<VerifyServiceProviderConfiguration> msaMetadataBundle;
     private final ManifestReader manifestReader;
     private final Client client;
+    private final IdaKeyStore keyStore;
 
     public VerifyServiceProviderFactory(
             VerifyServiceProviderConfiguration configuration,
@@ -59,13 +68,12 @@ public class VerifyServiceProviderFactory {
             MetadataResolverBundle<VerifyServiceProviderConfiguration> msaMetadataBundle,
             Client client) throws KeyException {
         this.configuration = configuration;
-        this.responseFactory = new ResponseFactory(
-            getDecryptionKeyPairs(
+        List<KeyPair> decryptionKeyPairs = getDecryptionKeyPairs(
                 configuration.getSamlPrimaryEncryptionKey(),
                 configuration.getSamlSecondaryEncryptionKey()
-            ),
-            configuration.getVerifyHubMetadata().getExpectedEntityId()
         );
+        this.keyStore = new IdaKeyStore(null, decryptionKeyPairs);
+        this.responseFactory = new ResponseFactory(decryptionKeyPairs);
         this.dateTimeComparator = new DateTimeComparator(configuration.getClockSkew());
         this.entityIdService = new EntityIdService(configuration.getServiceEntityIds());
         this.verifyMetadataBundler = verifyMetadataBundler;
@@ -134,7 +142,15 @@ public class VerifyServiceProviderFactory {
         );
 
         EidasMetadataResolverRepository eidasMetadataResolverRepository = getEidasMetadataResolverRepository();
-        Optional<EidasValidatorFactory> eidasValidatorFactory = Optional.of(new EidasValidatorFactory(eidasMetadataResolverRepository));
+        IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
+        UnsignedAssertionsResponseHandler unsignedAssertionsResponseHandler = new UnsignedAssertionsResponseHandler(
+                new EidasValidatorFactory(eidasMetadataResolverRepository),
+                createStringToResponseTransformer(),
+                new InstantValidator(dateTimeComparator),
+                new SecretKeyDecryptorFactory(idaKeyStoreCredentialRetriever),
+                anEidasEncryptionAlgorithmValidator()
+        );
+
 
         EidasAssertionTranslator eidasAssertionService = responseFactory.createEidasAssertionService(
                 dateTimeComparator,
@@ -143,14 +159,24 @@ public class VerifyServiceProviderFactory {
                 configuration.getHashingEntityId()
         );
 
-        AssertionTranslator assertionTranslator = new ClassifyingAssertionTranslator(verifyAssertionService, eidasAssertionService);
+        EidasUnsignedAssertionTranslator eidasUnsignedAssertionService = responseFactory.createEidasUnsignedAssertionService(
+                dateTimeComparator,
+                eidasMetadataResolverRepository,
+                configuration.getEuropeanIdentity().get(),
+                configuration.getHashingEntityId()
+        );
+
+        AssertionTranslator assertionTranslator = new ClassifyingAssertionTranslator(
+                verifyAssertionService,
+                eidasAssertionService,
+                eidasUnsignedAssertionService);
 
         return new TranslateSamlResponseResource(
                 responseFactory.createNonMatchingResponseService(
                         getHubSignatureTrustEngine(),
                         assertionTranslator,
                         dateTimeComparator,
-                        eidasValidatorFactory
+                        Optional.of(unsignedAssertionsResponseHandler)
                 ),
                 entityIdService);
     }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -98,7 +98,7 @@ public class ResponseFactory {
             new SamlResponseSignatureValidator(new SamlMessageSignatureValidator(metadataBackedSignatureValidator)),
             new InstantValidator(dateTimeComparator),
             new MatchingResponderCodeTranslator(),
-            Optional.empty()
+            null
         );
     }
 
@@ -106,7 +106,7 @@ public class ResponseFactory {
             ExplicitKeySignatureTrustEngine hubSignatureTrustEngine,
             AssertionTranslator nonMatchingAssertionTranslator,
             DateTimeComparator dateTimeComparator,
-            Optional<UnsignedAssertionsResponseHandler> unsignedAssertionsResponseHandler
+            UnsignedAssertionsResponseHandler unsignedAssertionsResponseHandler
     ) {
         AssertionDecrypter assertionDecrypter = createAssertionDecrypter();
         MetadataBackedSignatureValidator metadataBackedSignatureValidator = createMetadataBackedSignatureValidator(hubSignatureTrustEngine);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -123,7 +123,7 @@ public class ResponseFactory {
         );
     }
 
-    public MatchingAssertionTranslator createMsaAssertionService(
+    public MatchingAssertionTranslator createMsaAssertionTranslator(
             ExplicitKeySignatureTrustEngine signatureTrustEngine,
             SignatureValidatorFactory signatureValidatorFactory,
             DateTimeComparator dateTimeComparator
@@ -144,9 +144,9 @@ public class ResponseFactory {
         );
     }
 
-    public VerifyAssertionTranslator createVerifyIdpAssertionService(SamlAssertionsSignatureValidator hubSignatureValidator,
-                                                                     DateTimeComparator dateTimeComparator,
-                                                                     String hashingEntityId) {
+    public VerifyAssertionTranslator createVerifyIdpAssertionTranslator(SamlAssertionsSignatureValidator hubSignatureValidator,
+                                                                        DateTimeComparator dateTimeComparator,
+                                                                        String hashingEntityId) {
 
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
@@ -162,7 +162,7 @@ public class ResponseFactory {
             );
     }
 
-    public EidasAssertionTranslator createEidasAssertionService(
+    public EidasAssertionTranslator createEidasAssertionTranslator(
             DateTimeComparator dateTimeComparator,
             EidasMetadataResolverRepository eidasMetadataResolverRepository,
             EuropeanIdentityConfiguration europeanIdentityConfiguration,
@@ -185,7 +185,7 @@ public class ResponseFactory {
         );
     }
 
-    public EidasUnsignedAssertionTranslator createEidasUnsignedAssertionService(
+    public EidasUnsignedAssertionTranslator createEidasUnsignedAssertionTranslator(
             DateTimeComparator dateTimeComparator,
             EidasMetadataResolverRepository eidasMetadataResolverRepository,
             EuropeanIdentityConfiguration europeanIdentityConfiguration,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/factories/saml/ResponseFactory.java
@@ -144,15 +144,14 @@ public class ResponseFactory {
         );
     }
 
-    public VerifyAssertionTranslator createVerifyIdpAssertionService(ExplicitKeySignatureTrustEngine signatureTrustEngine,
-                                                                     SignatureValidatorFactory signatureValidatorFactory,
+    public VerifyAssertionTranslator createVerifyIdpAssertionService(SamlAssertionsSignatureValidator hubSignatureValidator,
                                                                      DateTimeComparator dateTimeComparator,
                                                                      String hashingEntityId) {
 
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
         return new VerifyAssertionTranslator(
-                signatureValidatorFactory.getSignatureValidator(signatureTrustEngine),
+                hubSignatureValidator,
                 new SubjectValidator(timeRestrictionValidator),
                 new AssertionAttributeStatementValidator(),
                 new VerifyMatchingDatasetUnmarshaller(new AddressFactory()),

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
@@ -1,0 +1,111 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
+import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
+import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_VERIFIED;
+
+public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTranslator {
+
+    private final InstantValidator instantValidator;
+    private final ConditionsValidator conditionsValidator;
+    private final LevelOfAssuranceValidator levelOfAssuranceValidator;
+    final EidasMetadataResolverRepository metadataResolverRepository;
+    final SignatureValidatorFactory signatureValidatorFactory;
+    private final List<String> acceptableHubConnectorEntityIds;
+    private UserIdHashFactory userIdHashFactory;
+    private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
+
+    public BaseEidasAssertionTranslator(
+            SubjectValidator subjectValidator,
+            MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
+            MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
+            InstantValidator instantValidator,
+            ConditionsValidator conditionsValidator,
+            LevelOfAssuranceValidator levelOfAssuranceValidator,
+            EidasMetadataResolverRepository metadataResolverRepository,
+            SignatureValidatorFactory signatureValidatorFactory,
+            List<String> acceptableHubConnectorEntityIds,
+            UserIdHashFactory userIdHashFactory) {
+        super(subjectValidator, matchingDatasetUnmarshaller, mdsMapper);
+        this.instantValidator = instantValidator;
+        this.conditionsValidator = conditionsValidator;
+        this.levelOfAssuranceValidator = levelOfAssuranceValidator;
+        this.metadataResolverRepository = metadataResolverRepository;
+        this.signatureValidatorFactory = signatureValidatorFactory;
+        this.acceptableHubConnectorEntityIds = acceptableHubConnectorEntityIds;
+        this.userIdHashFactory = userIdHashFactory;
+    }
+
+    abstract void validateSignature(Assertion assertion, String issuerEntityId);
+
+    @Override
+    public TranslatedNonMatchingResponseBody translateSuccessResponse(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
+        if (assertions.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one country assertion is expected.");
+        }
+
+        Assertion countryAssertion = assertions.get(0);
+
+        validateCountryAssertion(countryAssertion, expectedInResponseTo);
+
+        LevelOfAssurance levelOfAssurance = extractLevelOfAssuranceFrom(countryAssertion);
+        levelOfAssuranceValidator.validate(levelOfAssurance, expectedLevelOfAssurance);
+
+        String nameID = getNameIdFrom(countryAssertion);
+        String issuerID = countryAssertion.getIssuer().getValue();
+        String levelOfAssuranceUri =  extractLevelOfAssuranceUriFrom(countryAssertion);
+        Optional<AuthnContext> authnContext = getAuthnContext(levelOfAssuranceUri);
+        String hashId = userIdHashFactory.hashId(issuerID, nameID, authnContext);
+
+        NonMatchingAttributes attributes = translateAttributes(countryAssertion);
+
+        return new TranslatedNonMatchingResponseBody(IDENTITY_VERIFIED, hashId, levelOfAssurance, attributes);
+    }
+
+    private void validateCountryAssertion(Assertion assertion, String expectedInResponseTo) {
+        String issuerEntityId = assertion.getIssuer().getValue();
+        validateSignature(assertion, issuerEntityId);
+        instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
+        subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
+        conditionsValidator.validate(assertion.getConditions(), acceptableHubConnectorEntityIds.toArray(new String[0]));
+    }
+
+    public LevelOfAssurance extractLevelOfAssuranceFrom(Assertion countryAssertion) {
+        String levelOfAssuranceString = extractLevelOfAssuranceUriFrom(countryAssertion);
+
+        try {
+            return LevelOfAssurance.fromSamlValue(new AuthnContextFactory().mapFromEidasToLoA(levelOfAssuranceString).getUri());
+        } catch (Exception ex) {
+            throw new SamlResponseValidationException(String.format("Level of assurance '%s' is not supported.", levelOfAssuranceString));
+        }
+    }
+
+    Optional<AuthnContext> getAuthnContext(String uri) {
+        AuthnContext authnContext = authnContextFactory.mapFromEidasToLoA(uri);
+
+        return Optional.of(authnContext);
+    }
+
+    public Boolean isCountryAssertion(Assertion assertion) {
+        return metadataResolverRepository.getResolverEntityIds().contains(assertion.getIssuer().getValue());
+    }
+
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
@@ -13,9 +13,9 @@ import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory
 import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.EidasAssertionTranslatorValidatorContainer;
 import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
 import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
-import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,20 +35,17 @@ public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTran
     private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
 
     public BaseEidasAssertionTranslator(
-            SubjectValidator subjectValidator,
+            EidasAssertionTranslatorValidatorContainer validatorContainer,
             MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
             MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
-            InstantValidator instantValidator,
-            ConditionsValidator conditionsValidator,
-            LevelOfAssuranceValidator levelOfAssuranceValidator,
             EidasMetadataResolverRepository metadataResolverRepository,
             SignatureValidatorFactory signatureValidatorFactory,
             List<String> acceptableHubConnectorEntityIds,
             UserIdHashFactory userIdHashFactory) {
-        super(subjectValidator, matchingDatasetUnmarshaller, mdsMapper);
-        this.instantValidator = instantValidator;
-        this.conditionsValidator = conditionsValidator;
-        this.levelOfAssuranceValidator = levelOfAssuranceValidator;
+        super(validatorContainer.getSubjectValidator(), matchingDatasetUnmarshaller, mdsMapper);
+        this.instantValidator = validatorContainer.getInstantValidator();
+        this.conditionsValidator = validatorContainer.getConditionsValidator();
+        this.levelOfAssuranceValidator = validatorContainer.getLevelOfAssuranceValidator();
         this.metadataResolverRepository = metadataResolverRepository;
         this.signatureValidatorFactory = signatureValidatorFactory;
         this.acceptableHubConnectorEntityIds = acceptableHubConnectorEntityIds;

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
@@ -27,8 +27,8 @@ public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTran
     private final InstantValidator instantValidator;
     private final ConditionsValidator conditionsValidator;
     private final LevelOfAssuranceValidator levelOfAssuranceValidator;
-    final EidasMetadataResolverRepository metadataResolverRepository;
-    final SignatureValidatorFactory signatureValidatorFactory;
+    protected final EidasMetadataResolverRepository metadataResolverRepository;
+    protected SignatureValidatorFactory signatureValidatorFactory;
     private final List<String> acceptableHubConnectorEntityIds;
     private UserIdHashFactory userIdHashFactory;
     private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
@@ -54,7 +54,7 @@ public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTran
         this.userIdHashFactory = userIdHashFactory;
     }
 
-    abstract void validateSignature(Assertion assertion, String issuerEntityId);
+    protected abstract void validateSignature(Assertion assertion, String issuerEntityId);
 
     @Override
     public TranslatedNonMatchingResponseBody translateSuccessResponse(List<Assertion> assertions, String expectedInResponseTo, LevelOfAssurance expectedLevelOfAssurance, String entityId) {
@@ -98,7 +98,7 @@ public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTran
         }
     }
 
-    Optional<AuthnContext> getAuthnContext(String uri) {
+    private Optional<AuthnContext> getAuthnContext(String uri) {
         AuthnContext authnContext = authnContextFactory.mapFromEidasToLoA(uri);
 
         return Optional.of(authnContext);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslator.java
@@ -24,6 +24,7 @@ import static uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario.IDENTITY_
 
 public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTranslator {
 
+    private final int ONLY_ONE_PRESENT = 0;
     private final InstantValidator instantValidator;
     private final ConditionsValidator conditionsValidator;
     private final LevelOfAssuranceValidator levelOfAssuranceValidator;
@@ -62,7 +63,7 @@ public abstract class BaseEidasAssertionTranslator extends IdentityAssertionTran
             throw new SamlResponseValidationException("Exactly one country assertion is expected.");
         }
 
-        Assertion countryAssertion = assertions.get(0);
+        Assertion countryAssertion = assertions.get(ONLY_ONE_PRESENT);
 
         validateCountryAssertion(countryAssertion, expectedInResponseTo);
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ClassifyingAssertionTranslator.java
@@ -10,14 +10,17 @@ public class ClassifyingAssertionTranslator implements AssertionTranslator {
 
     private final VerifyAssertionTranslator verifyAssertionTranslator;
     private final EidasAssertionTranslator eidasAssertionTranslator;
+    private final EidasUnsignedAssertionTranslator eidasUnsignedAssertionTranslator;
 
 
     public ClassifyingAssertionTranslator(
             VerifyAssertionTranslator verifyAssertionTranslator,
-            EidasAssertionTranslator eidasAssertionTranslator
+            EidasAssertionTranslator eidasAssertionTranslator,
+            EidasUnsignedAssertionTranslator eidasUnsignedAssertionTranslator
     ) {
         this.verifyAssertionTranslator = verifyAssertionTranslator;
         this.eidasAssertionTranslator = eidasAssertionTranslator;
+        this.eidasUnsignedAssertionTranslator = eidasUnsignedAssertionTranslator;
     }
 
 
@@ -29,9 +32,12 @@ public class ClassifyingAssertionTranslator implements AssertionTranslator {
     }
 
     private IdentityAssertionTranslator getAssertionService(List<Assertion> assertions) {
-        return isEidasIdentity(assertions) ? eidasAssertionTranslator : verifyAssertionTranslator;
+        return isEidasIdentity(assertions) ? getEidasAssertionService(assertions) : verifyAssertionTranslator;
     }
 
+    private IdentityAssertionTranslator getEidasAssertionService(List<Assertion> assertions) {
+        return assertions.get(0).getSignature() == null ? eidasUnsignedAssertionTranslator : eidasAssertionTranslator;
+    }
 
     private boolean isEidasIdentity(List<Assertion> assertions) {
         return assertions.stream().anyMatch(eidasAssertionTranslator::isCountryAssertion);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
@@ -41,11 +41,10 @@ public class EidasAssertionTranslator extends BaseEidasAssertionTranslator {
                 acceptableHubConnectorEntityIds,
                 userIdHashFactory
         );
-
     }
 
     @Override
-    void validateSignature(Assertion assertion, String issuerEntityId) {
+    protected void validateSignature(Assertion assertion, String issuerEntityId) {
         metadataResolverRepository.getSignatureTrustEngine(issuerEntityId)
                 .map(signatureValidatorFactory::getSignatureValidator)
                 .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + issuerEntityId))

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslator.java
@@ -8,10 +8,7 @@ import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
-import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
-import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
-import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
-import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+import uk.gov.ida.verifyserviceprovider.validators.EidasAssertionTranslatorValidatorContainer;
 
 import java.util.List;
 
@@ -19,23 +16,17 @@ import static java.util.Collections.singletonList;
 
 public class EidasAssertionTranslator extends BaseEidasAssertionTranslator {
     public EidasAssertionTranslator(
-            SubjectValidator subjectValidator,
+            EidasAssertionTranslatorValidatorContainer validatorContainer,
             MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
             MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
-            InstantValidator instantValidator,
-            ConditionsValidator conditionsValidator,
-            LevelOfAssuranceValidator levelOfAssuranceValidator,
             EidasMetadataResolverRepository metadataResolverRepository,
             SignatureValidatorFactory signatureValidatorFactory,
             List<String> acceptableHubConnectorEntityIds,
             UserIdHashFactory userIdHashFactory) {
         super(
-                subjectValidator,
+                validatorContainer,
                 matchingDatasetUnmarshaller,
                 mdsMapper,
-                instantValidator,
-                conditionsValidator,
-                levelOfAssuranceValidator,
                 metadataResolverRepository,
                 signatureValidatorFactory,
                 acceptableHubConnectorEntityIds,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
@@ -1,11 +1,8 @@
 package uk.gov.ida.verifyserviceprovider.services;
 
 import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
-import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
-import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
 import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
@@ -15,10 +12,8 @@ import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
-
-public class EidasAssertionTranslator extends BaseEidasAssertionTranslator {
-    public EidasAssertionTranslator(
+public class EidasUnsignedAssertionTranslator extends BaseEidasAssertionTranslator {
+    public EidasUnsignedAssertionTranslator(
             SubjectValidator subjectValidator,
             MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
             MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
@@ -26,10 +21,9 @@ public class EidasAssertionTranslator extends BaseEidasAssertionTranslator {
             ConditionsValidator conditionsValidator,
             LevelOfAssuranceValidator levelOfAssuranceValidator,
             EidasMetadataResolverRepository metadataResolverRepository,
-            SignatureValidatorFactory signatureValidatorFactory,
             List<String> acceptableHubConnectorEntityIds,
             UserIdHashFactory userIdHashFactory) {
-        super(
+            super(
                 subjectValidator,
                 matchingDatasetUnmarshaller,
                 mdsMapper,
@@ -37,20 +31,14 @@ public class EidasAssertionTranslator extends BaseEidasAssertionTranslator {
                 conditionsValidator,
                 levelOfAssuranceValidator,
                 metadataResolverRepository,
-                signatureValidatorFactory,
+                null,
                 acceptableHubConnectorEntityIds,
                 userIdHashFactory
         );
-
     }
 
     @Override
     void validateSignature(Assertion assertion, String issuerEntityId) {
-        metadataResolverRepository.getSignatureTrustEngine(issuerEntityId)
-                .map(signatureValidatorFactory::getSignatureValidator)
-                .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + issuerEntityId))
-                .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        // No need to validate the signature of an unsigned assertion.
     }
-
-
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
@@ -5,31 +5,22 @@ import uk.gov.ida.saml.core.transformers.MatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
-import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
-import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
-import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
-import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+import uk.gov.ida.verifyserviceprovider.validators.EidasAssertionTranslatorValidatorContainer;
 
 import java.util.List;
 
 public class EidasUnsignedAssertionTranslator extends BaseEidasAssertionTranslator {
     public EidasUnsignedAssertionTranslator(
-            SubjectValidator subjectValidator,
+            EidasAssertionTranslatorValidatorContainer validatorContainer,
             MatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
             MatchingDatasetToNonMatchingAttributesMapper mdsMapper,
-            InstantValidator instantValidator,
-            ConditionsValidator conditionsValidator,
-            LevelOfAssuranceValidator levelOfAssuranceValidator,
             EidasMetadataResolverRepository metadataResolverRepository,
             List<String> acceptableHubConnectorEntityIds,
             UserIdHashFactory userIdHashFactory) {
             super(
-                subjectValidator,
+                validatorContainer,
                 matchingDatasetUnmarshaller,
                 mdsMapper,
-                instantValidator,
-                conditionsValidator,
-                levelOfAssuranceValidator,
                 metadataResolverRepository,
                 null,
                 acceptableHubConnectorEntityIds,

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslator.java
@@ -38,7 +38,7 @@ public class EidasUnsignedAssertionTranslator extends BaseEidasAssertionTranslat
     }
 
     @Override
-    void validateSignature(Assertion assertion, String issuerEntityId) {
+    protected void validateSignature(Assertion assertion, String issuerEntityId) {
         // No need to validate the signature of an unsigned assertion.
     }
 }

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
@@ -73,7 +73,7 @@ public class ResponseService {
                 if (assertionsContainEidasUnsignedAssertionsResponse(assertions)) {
                     UnsignedAssertionsResponseHandler handler = unsignedAssertionsResponseHandler.get();
 
-                    ValidatedResponse validatedCountryResponse = handler.getValidatedResponse(assertions.get(0), expectedInResponseTo);
+                    ValidatedResponse validatedCountryResponse = handler.getValidatedResponse(assertions, expectedInResponseTo);
                     assertions = handler.decryptAssertion(validatedCountryResponse, assertions.get(0));
                 }
                 return assertionTranslator.translateSuccessResponse(assertions, expectedInResponseTo, expectedLevelOfAssurance, entityId);

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/ResponseService.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 public class ResponseService {
 
+    private final int ONLY_ONE_PRESENT = 0;
     private final StringToOpenSamlObjectTransformer<Response> samlObjectTransformer;
     private final AssertionDecrypter assertionDecrypter;
     private final AssertionTranslator assertionTranslator;
@@ -74,7 +75,7 @@ public class ResponseService {
                     if (unsignedAssertionsResponseHandler == null) { throw new MissingUnsignedAssertionsHandlerException(); }
 
                     ValidatedResponse validatedCountryResponse = unsignedAssertionsResponseHandler.getValidatedResponse(assertions, expectedInResponseTo);
-                    assertions = unsignedAssertionsResponseHandler.decryptAssertion(validatedCountryResponse, assertions.get(0));
+                    assertions = unsignedAssertionsResponseHandler.decryptAssertion(validatedCountryResponse, assertions.get(ONLY_ONE_PRESENT));
                 }
                 return assertionTranslator.translateSuccessResponse(assertions, expectedInResponseTo, expectedLevelOfAssurance, entityId);
             default:
@@ -85,10 +86,10 @@ public class ResponseService {
     private boolean assertionsContainEidasUnsignedAssertionsResponse(List<Assertion> assertions) {
         if (assertions == null || assertions.size() != 1) { return false; }
 
-        List<AttributeStatement> attributeStatements = assertions.get(0).getAttributeStatements();
+        List<AttributeStatement> attributeStatements = assertions.get(ONLY_ONE_PRESENT).getAttributeStatements();
         if (attributeStatements.isEmpty() || attributeStatements.size() != 1) { return false; }
 
-        return attributeStatements.get(0).getAttributes()
+        return attributeStatements.get(ONLY_ONE_PRESENT).getAttributes()
                 .stream()
                 .anyMatch(
                         attribute -> attribute.getName().equals(

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionsResponseHandler.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionsResponseHandler.java
@@ -33,6 +33,7 @@ import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.una
 public class UnsignedAssertionsResponseHandler {
     private static final Logger LOG = LoggerFactory.getLogger(UnsignedAssertionsResponseHandler.class);
 
+    private final int ONLY_ONE_PRESENT = 0;
     private final EidasValidatorFactory eidasValidatorFactory;
     private final StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer;
     private final InstantValidator instantValidator;
@@ -63,7 +64,7 @@ public class UnsignedAssertionsResponseHandler {
         ValidatedAssertions validatedHubAssertion = hubAssertionsSignatureValidator.validate(hubResponseAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
         ValidatedResponse validatedResponse = eidasValidatorFactory.getValidatedResponse(
                 stringToResponseTransformer.apply(
-                        getCountryResponseStringFromAssertion(validatedHubAssertion.getAssertions().get(0))
+                        getCountryResponseStringFromAssertion(validatedHubAssertion.getAssertions().get(ONLY_ONE_PRESENT))
                 )
         );
 
@@ -112,8 +113,8 @@ public class UnsignedAssertionsResponseHandler {
     }
 
     private String getCountryResponseStringFromAssertion(Assertion hubResponseAssertion) {
-        List<Attribute> attributes = hubResponseAssertion.getAttributeStatements().get(0).getAttributes();
-        CountrySamlResponse countrySamlResponse = (CountrySamlResponse) attributes.get(0).getAttributeValues().get(0);
+        List<Attribute> attributes = hubResponseAssertion.getAttributeStatements().get(ONLY_ONE_PRESENT).getAttributes();
+        CountrySamlResponse countrySamlResponse = (CountrySamlResponse) attributes.get(ONLY_ONE_PRESENT).getAttributeValues().get(ONLY_ONE_PRESENT);
         return countrySamlResponse.getValue();
     }
 

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionsResponseHandler.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionsResponseHandler.java
@@ -1,0 +1,129 @@
+package uk.gov.ida.verifyserviceprovider.services;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.EidasValidatorFactory;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
+import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+
+import javax.crypto.NoSuchPaddingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.unableToDecrypt;
+
+public class UnsignedAssertionsResponseHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(UnsignedAssertionsResponseHandler.class);
+
+    private final EidasValidatorFactory eidasValidatorFactory;
+    private final StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer;
+    private final InstantValidator instantValidator;
+    private final SecretKeyDecryptorFactory secretKeyDecryptorFactory;
+    private final EncryptionAlgorithmValidator encryptionAlgorithmValidator;
+
+    public UnsignedAssertionsResponseHandler (
+            EidasValidatorFactory eidasValidatorFactory,
+            StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer,
+            InstantValidator instantValidator,
+            SecretKeyDecryptorFactory secretKeyDecryptorFactory,
+            EncryptionAlgorithmValidator encryptionAlgorithmValidator
+    ) {
+        this.eidasValidatorFactory = eidasValidatorFactory;
+        this.stringToResponseTransformer = stringToResponseTransformer;
+        this.instantValidator = instantValidator;
+        this.secretKeyDecryptorFactory = secretKeyDecryptorFactory;
+        this.encryptionAlgorithmValidator = encryptionAlgorithmValidator;
+    }
+
+    public ValidatedResponse getValidatedResponse(
+            Assertion hubResponseAssertion,
+            String expectedInResponseTo
+    ) {
+        ValidatedResponse validatedResponse = eidasValidatorFactory.getValidatedResponse(
+                stringToResponseTransformer.apply(
+                        getCountryResponseStringFromAssertion(hubResponseAssertion)
+                )
+        );
+
+        if (!expectedInResponseTo.equals(validatedResponse.getInResponseTo())) {
+            throw new SamlResponseValidationException(
+                    String.format("Expected InResponseTo to be %s, but was %s", expectedInResponseTo, validatedResponse.getInResponseTo())
+            );
+        }
+
+        instantValidator.validate(validatedResponse.getIssueInstant(), "Response IssueInstant");
+
+        return validatedResponse;
+    }
+
+    public List<Assertion> decryptAssertion(
+            ValidatedResponse validatedResponse,
+            Assertion hubResponseAssertion
+    ) {
+        Iterator<String> keysIterator = getEncryptedAssertionKeysFromAssertion(hubResponseAssertion).iterator();
+
+        while (keysIterator.hasNext()) {
+            String key = keysIterator.next();
+            try {
+                return getAssertionDecrypter(key).decryptAssertions(validatedResponse);
+            } catch (Exception e) {
+                if (keysIterator.hasNext()) {
+                    LOG.info("Failed to decrypt assertions with key, trying next available", e);
+                } else {
+                    String message = String.format("Failed to decrypt assertions with any key for response ID %s", validatedResponse.getID());
+                    throw new SamlFailedToDecryptException(unableToDecrypt(message), e);
+                }
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    private AssertionDecrypter getAssertionDecrypter(String key) {
+        try {
+            return new AssertionDecrypter(
+                    encryptionAlgorithmValidator,
+                    secretKeyDecryptorFactory.createDecrypter(key)
+            );
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException e) {
+            throw new SamlFailedToDecryptException(unableToDecrypt("Unable to create decrypter from encrypted key"), e);
+        }
+    }
+
+    private String getCountryResponseStringFromAssertion(Assertion hubResponseAssertion) {
+        List<Attribute> attributes = hubResponseAssertion.getAttributeStatements().get(0).getAttributes();
+        CountrySamlResponse countrySamlResponse = (CountrySamlResponse) attributes.get(0).getAttributeValues().get(0);
+        return countrySamlResponse.getValue();
+    }
+
+    private List<String> getEncryptedAssertionKeysFromAssertion(Assertion hubResponseAssertion) {
+        List<String> keys = new ArrayList<String>();
+        hubResponseAssertion
+                .getAttributeStatements()
+                .get(0)
+                .getAttributes()
+                .stream()
+                .filter(attribute -> attribute.getName().equals(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME))
+                .forEach(attribute -> attribute
+                        .getAttributeValues()
+                        .stream()
+                        .map(value -> (EncryptedAssertionKeys) value)
+                        .forEach(value -> keys.add(value.getValue()))
+                );
+        return keys;
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasAssertionTranslatorValidatorContainer.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasAssertionTranslatorValidatorContainer.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.verifyserviceprovider.validators;
+
+public class EidasAssertionTranslatorValidatorContainer {
+    private final SubjectValidator subjectValidator;
+    private final InstantValidator instantValidator;
+    private final ConditionsValidator conditionsValidator;
+    private final LevelOfAssuranceValidator levelOfAssuranceValidator;
+
+    public EidasAssertionTranslatorValidatorContainer(
+            SubjectValidator subjectValidator,
+            InstantValidator instantValidator,
+            ConditionsValidator conditionsValidator,
+            LevelOfAssuranceValidator levelOfAssuranceValidator
+    ) {
+        this.subjectValidator = subjectValidator;
+        this.instantValidator = instantValidator;
+        this.conditionsValidator = conditionsValidator;
+        this.levelOfAssuranceValidator = levelOfAssuranceValidator;
+    };
+
+    public SubjectValidator getSubjectValidator() { return subjectValidator; }
+    public InstantValidator getInstantValidator() { return instantValidator; }
+    public ConditionsValidator getConditionsValidator() { return conditionsValidator; }
+    public LevelOfAssuranceValidator getLevelOfAssuranceValidator() { return levelOfAssuranceValidator; }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasEncryptionAlgorithmValidator.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasEncryptionAlgorithmValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.verifyserviceprovider.validators;
+
+import com.google.common.collect.ImmutableSet;
+import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
+import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
+
+public class EidasEncryptionAlgorithmValidator {
+    public static EncryptionAlgorithmValidator anEidasEncryptionAlgorithmValidator() {
+        return new EncryptionAlgorithmValidator(
+                ImmutableSet.of(
+                        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM,
+                        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192_GCM,
+                        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM
+                ),
+                ImmutableSet.of(
+                        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP,
+                        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11
+                )
+        );
+    }
+}

--- a/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasEncryptionAlgorithmValidatorHelper.java
+++ b/src/main/java/uk/gov/ida/verifyserviceprovider/validators/EidasEncryptionAlgorithmValidatorHelper.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
 
-public class EidasEncryptionAlgorithmValidator {
+public class EidasEncryptionAlgorithmValidatorHelper {
     public static EncryptionAlgorithmValidator anEidasEncryptionAlgorithmValidator() {
         return new EncryptionAlgorithmValidator(
                 ImmutableSet.of(

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/resources/GenerateAuthnRequestResourceTest.java
@@ -37,8 +37,6 @@ import uk.gov.ida.verifyserviceprovider.services.EntityIdService;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Map;

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/ResponseFactoryTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/ResponseFactoryTest.java
@@ -12,6 +12,7 @@ import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
 import java.util.Base64;
 import java.util.Collections;
 
+
 public class ResponseFactoryTest {
 
     @Rule
@@ -20,26 +21,25 @@ public class ResponseFactoryTest {
     private StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer = ResponseFactory.createStringToResponseTransformer();
 
     @Test
-    public void shouldNotAllowNullSamlResponse() {
+    public void createStringToResponseTransformerShouldNotAllowNullSamlResponse() {
         expectedException.expect(SamlTransformationErrorException.class);
         expectedException.expectMessage("SAML Validation Specification: Missing SAML message.");
         stringToResponseTransformer.apply(null);
     }
 
     @Test
-    public void shouldNotAllowNotBase64EncodedSamlResponse() {
+    public void createStringToResponseTransformerShouldNotAllowNotBase64EncodedSamlResponse() {
         expectedException.expect(SamlTransformationErrorException.class);
         expectedException.expectMessage("SAML Validation Specification: SAML is not base64 encoded in message body. start> not-encoded-string <end");
         stringToResponseTransformer.apply("not-encoded-string");
     }
 
     @Test
-    public void shouldNotAllowTooLongSamlMessages() {
+    public void createStringToResponseTransformerShouldNotAllowTooLongSamlMessages() {
         String longString = String.join("", Collections.nCopies(50001, "a"));
         String longBase64EncodedString = Base64.getEncoder().encodeToString(longString.getBytes());
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("SAML Response is too long.");
         stringToResponseTransformer.apply(longBase64EncodedString);
     }
-
 }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/ResponseFactoryTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/saml/ResponseFactoryTest.java
@@ -28,7 +28,7 @@ public class ResponseFactoryTest {
     }
 
     @Test
-    public void createStringToResponseTransformerShouldNotAllowNotBase64EncodedSamlResponse() {
+    public void createStringToResponseTransformerMustContainBase64EncodedSamlResponse() {
         expectedException.expect(SamlTransformationErrorException.class);
         expectedException.expectMessage("SAML Validation Specification: SAML is not base64 encoded in message body. start> not-encoded-string <end");
         stringToResponseTransformer.apply("not-encoded-string");

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
@@ -51,7 +51,7 @@ import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 
 public abstract class BaseEidasAssertionTranslatorTestBase {
 
-    BaseEidasAssertionTranslator assertionService;
+    protected BaseEidasAssertionTranslator assertionService;
     @Mock
     SubjectValidator subjectValidator;
     @Mock
@@ -73,7 +73,7 @@ public abstract class BaseEidasAssertionTranslatorTestBase {
     @Mock
     UserIdHashFactory userIdHashFactory;
 
-    abstract void shouldCallValidatorsCorrectly();
+    protected abstract void shouldCallValidatorsCorrectly();
 
     @Test
     public void shouldTranslateEidasAssertion() {
@@ -132,7 +132,7 @@ public abstract class BaseEidasAssertionTranslatorTestBase {
     }
 
 
-    static AssertionBuilder anAssertionWithAuthnStatement(String authnContext, String inResponseTo) {
+    protected static AssertionBuilder anAssertionWithAuthnStatement(String authnContext, String inResponseTo) {
         return anAssertion()
             .addAuthnStatement(
                 anAuthnStatement()

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
@@ -21,6 +21,7 @@ import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
 import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
 import uk.gov.ida.verifyserviceprovider.services.BaseEidasAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.EidasAssertionTranslatorValidatorContainer;
 import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
 import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
 import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
@@ -160,5 +161,14 @@ public abstract class BaseEidasAssertionTranslatorTestBase {
                             .build()
                     ).build()
             ).build();
+    }
+
+    protected EidasAssertionTranslatorValidatorContainer getEidasAssertionTranslatorValidatorContainer() {
+        return new EidasAssertionTranslatorValidatorContainer(
+                subjectValidator,
+                instantValidator,
+                conditionsValidator,
+                levelOfAssuranceValidator
+        );
     }
 }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/BaseEidasAssertionTranslatorTestBase.java
@@ -1,0 +1,164 @@
+package unit.uk.gov.ida.verifyserviceprovider.services;
+
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.transformers.EidasMatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingScenario;
+import uk.gov.ida.verifyserviceprovider.dto.TestTranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.factories.saml.SignatureValidatorFactory;
+import uk.gov.ida.verifyserviceprovider.factories.saml.UserIdHashFactory;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.services.BaseEidasAssertionTranslator;
+import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+import uk.gov.ida.verifyserviceprovider.validators.LevelOfAssuranceValidator;
+import uk.gov.ida.verifyserviceprovider.validators.SubjectValidator;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.extensions.EidasAuthnContext.EIDAS_LOA_SUBSTANTIAL;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_COUNTRY_ONE;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.IPAddressAttributeBuilder.anIPAddress;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
+
+public abstract class BaseEidasAssertionTranslatorTestBase {
+
+    BaseEidasAssertionTranslator assertionService;
+    @Mock
+    SubjectValidator subjectValidator;
+    @Mock
+    EidasMatchingDatasetUnmarshaller eidasMatchingDatasetUnmarshaller;
+    @Mock
+    MatchingDatasetToNonMatchingAttributesMapper mdsMapper;
+    @Mock
+    InstantValidator instantValidator;
+    @Mock
+    ConditionsValidator conditionsValidator;
+    @Mock
+    LevelOfAssuranceValidator levelOfAssuranceValidator;
+    @Mock
+    EidasMetadataResolverRepository metadataResolverRepository;
+    @Mock
+    SignatureValidatorFactory signatureValidatorFactory;
+    @Mock
+    SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    @Mock
+    UserIdHashFactory userIdHashFactory;
+
+    abstract void shouldCallValidatorsCorrectly();
+
+    @Test
+    public void shouldTranslateEidasAssertion() {
+        Assertion eidasAssertion = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        assertionService.translateSuccessResponse(singletonList(eidasAssertion), "requestId", LEVEL_2, null);
+
+        verify(eidasMatchingDatasetUnmarshaller, times(1)).fromAssertion(eidasAssertion);
+    }
+
+    @Test
+    public void shouldCorrectlyExtractLevelOfAssurance() {
+        Assertion eidasAssertion = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+
+        LevelOfAssurance loa = assertionService.extractLevelOfAssuranceFrom(eidasAssertion);
+
+        assertThat(loa).isEqualTo(LEVEL_2);
+    }
+
+    @Test
+    public void expectedHashContainedInResponseBodyWhenUserIdFactoryIsCalledOnce() {
+        String requestId = "requestId";
+        String expectedHashed = "a5fbea969c3837a712cbe9e188804796828f369106478e623a436fa07e8fd298";
+        TestTranslatedNonMatchingResponseBody expectedNonMatchingResponseBody = new TestTranslatedNonMatchingResponseBody(NonMatchingScenario.IDENTITY_VERIFIED, expectedHashed, LEVEL_2, null);
+
+        Assertion eidasAssertion = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, requestId).buildUnencrypted();
+
+        final String nameId = eidasAssertion.getSubject().getNameID().getValue();
+        final String issuerId = eidasAssertion.getIssuer().getValue();
+
+        when(userIdHashFactory.hashId(eq(issuerId), eq(nameId), eq(Optional.of(AuthnContext.LEVEL_2))))
+                .thenReturn(expectedHashed);
+
+        TranslatedNonMatchingResponseBody responseBody = assertionService.translateSuccessResponse(ImmutableList.of(eidasAssertion), "requestId", LEVEL_2, "default-entity-id");
+
+        verify(userIdHashFactory, times(1)).hashId(issuerId,nameId, Optional.of(AuthnContext.LEVEL_2));
+        assertThat(responseBody.toString()).contains(expectedNonMatchingResponseBody.getPid());
+    }
+
+    @Test(expected = SamlResponseValidationException.class)
+    public void shouldThrowAnExceptionIfMultipleAssertionsReceived() {
+        Assertion eidasAssertion1 = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        Assertion eidasAssertion2 = anAssertionWithAuthnStatement(EIDAS_LOA_SUBSTANTIAL, "requestId").buildUnencrypted();
+        assertionService.translateSuccessResponse(asList(eidasAssertion1, eidasAssertion2), "requestId", LEVEL_2, null);
+    }
+
+    @Test
+    public void shouldCorrectlyIdentifyCountryAssertions() {
+        List<String> resolverEntityIds = asList("ID1", "ID2");
+        when(metadataResolverRepository.getResolverEntityIds()).thenReturn(resolverEntityIds);
+
+        Assertion countryAssertion = anAssertion().withIssuer(anIssuer().withIssuerId("ID1").build()).buildUnencrypted();
+        Assertion idpAssertion = anAssertion().withIssuer(anIssuer().withIssuerId("ID3").build()).buildUnencrypted();
+
+        assertThat(assertionService.isCountryAssertion(countryAssertion)).isTrue();
+        assertThat(assertionService.isCountryAssertion(idpAssertion)).isFalse();
+    }
+
+
+    static AssertionBuilder anAssertionWithAuthnStatement(String authnContext, String inResponseTo) {
+        return anAssertion()
+            .addAuthnStatement(
+                anAuthnStatement()
+                    .withAuthnContext(
+                        anAuthnContext()
+                            .withAuthnContextClassRef(
+                                anAuthnContextClassRef()
+                                    .withAuthnContextClasRefValue(authnContext)
+                                    .build())
+                            .build())
+                    .build())
+            .withSubject(anAssertionSubject(inResponseTo))
+            .withIssuer(anIssuer().withIssuerId(STUB_COUNTRY_ONE).build())
+            .addAttributeStatement(anAttributeStatement().addAttribute(anIPAddress().build()).build());
+    }
+
+    private static Subject anAssertionSubject(final String inResponseTo) {
+        return aSubject()
+            .withSubjectConfirmation(
+                aSubjectConfirmation()
+                    .withSubjectConfirmationData(
+                        aSubjectConfirmationData()
+                            .withNotOnOrAfter(DateTime.now())
+                            .withInResponseTo(inResponseTo)
+                            .build()
+                    ).build()
+            ).build();
+    }
+}

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasAssertionTranslatorTest.java
@@ -32,12 +32,9 @@ public class EidasAssertionTranslatorTest extends BaseEidasAssertionTranslatorTe
         IdaSamlBootstrap.bootstrap();
         initMocks(this);
         assertionService = new EidasAssertionTranslator(
-                subjectValidator,
+                getEidasAssertionTranslatorValidatorContainer(),
                 eidasMatchingDatasetUnmarshaller,
                 mdsMapper,
-                instantValidator,
-                conditionsValidator,
-                levelOfAssuranceValidator,
                 metadataResolverRepository,
                 signatureValidatorFactory,
                 singletonList(HUB_CONNECTOR_ENTITY_ID),

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslatorTest.java
@@ -33,12 +33,9 @@ public class EidasUnsignedAssertionTranslatorTest extends BaseEidasAssertionTran
         IdaSamlBootstrap.bootstrap();
         initMocks(this);
         assertionService = new EidasUnsignedAssertionTranslator(
-                subjectValidator,
+                getEidasAssertionTranslatorValidatorContainer(),
                 eidasMatchingDatasetUnmarshaller,
                 mdsMapper,
-                instantValidator,
-                conditionsValidator,
-                levelOfAssuranceValidator,
                 metadataResolverRepository,
                 singletonList(HUB_CONNECTOR_ENTITY_ID),
                 userIdHashFactory);

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/EidasUnsignedAssertionTranslatorTest.java
@@ -6,7 +6,7 @@ import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
-import uk.gov.ida.verifyserviceprovider.services.EidasAssertionTranslator;
+import uk.gov.ida.verifyserviceprovider.services.EidasUnsignedAssertionTranslator;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,13 +26,13 @@ import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_COUNTRY_ONE;
 import static uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance.LEVEL_2;
 
-public class EidasAssertionTranslatorTest extends BaseEidasAssertionTranslatorTestBase {
+public class EidasUnsignedAssertionTranslatorTest extends BaseEidasAssertionTranslatorTestBase {
 
     @Before
     public void setUp() {
         IdaSamlBootstrap.bootstrap();
         initMocks(this);
-        assertionService = new EidasAssertionTranslator(
+        assertionService = new EidasUnsignedAssertionTranslator(
                 subjectValidator,
                 eidasMatchingDatasetUnmarshaller,
                 mdsMapper,
@@ -39,7 +40,6 @@ public class EidasAssertionTranslatorTest extends BaseEidasAssertionTranslatorTe
                 conditionsValidator,
                 levelOfAssuranceValidator,
                 metadataResolverRepository,
-                signatureValidatorFactory,
                 singletonList(HUB_CONNECTOR_ENTITY_ID),
                 userIdHashFactory);
         doNothing().when(instantValidator).validate(any(), any());
@@ -65,6 +65,7 @@ public class EidasAssertionTranslatorTest extends BaseEidasAssertionTranslatorTe
         verify(subjectValidator, times(1)).validate(any(), any());
         verify(conditionsValidator, times(1)).validate(any(), any());
         verify(levelOfAssuranceValidator, times(1)).validate(any(), any());
-        verify(samlAssertionsSignatureValidator, times(1)).validate(any(), any());
+
+        verify(samlAssertionsSignatureValidator, never()).validate(any(), any());
     }
 }

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionTranslatorTest.java
@@ -63,7 +63,6 @@ public class MatchingAssertionTranslatorTest {
 
     private static final String IN_RESPONSE_TO = "_some-request-id";
     private static final String VERIFY_SERVICE_PROVIDER_ENTITY_ID = "default-entity-id";
-    private static final String VERIFY_HUB_ENTITY_ID = "hub-entity-id";
     private MatchingAssertionTranslator msaAssertionService;
     private Credential testRpMsaSigningCredential = createMSSigningCredential();
 
@@ -78,7 +77,7 @@ public class MatchingAssertionTranslatorTest {
         PrivateKey privateKey = new PrivateKeyStoreFactory().create(TestEntityIds.TEST_RP).getEncryptionPrivateKeys().get(0);
         KeyPair keyPair = new KeyPair(KeySupport.derivePublicKey(privateKey), privateKey);
         List<KeyPair> keyPairs = asList(keyPair, keyPair);
-        ResponseFactory responseFactory = new ResponseFactory(keyPairs, VERIFY_HUB_ENTITY_ID);
+        ResponseFactory responseFactory = new ResponseFactory(keyPairs);
 
         CollectionCredentialResolver resolver = new CollectionCredentialResolver(asList(testRpMsaSigningCredential));
         ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine = new ExplicitKeySignatureTrustEngine(resolver, DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionTranslatorTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/MatchingAssertionTranslatorTest.java
@@ -63,7 +63,7 @@ public class MatchingAssertionTranslatorTest {
 
     private static final String IN_RESPONSE_TO = "_some-request-id";
     private static final String VERIFY_SERVICE_PROVIDER_ENTITY_ID = "default-entity-id";
-    private MatchingAssertionTranslator msaAssertionService;
+    private MatchingAssertionTranslator msaAssertionTranslator;
     private Credential testRpMsaSigningCredential = createMSSigningCredential();
 
     private Credential createMSSigningCredential() {
@@ -84,7 +84,7 @@ public class MatchingAssertionTranslatorTest {
 
         DateTimeComparator dateTimeComparator = new DateTimeComparator(Duration.standardSeconds(5));
 
-        msaAssertionService = responseFactory.createMsaAssertionService(explicitKeySignatureTrustEngine, new SignatureValidatorFactory(), dateTimeComparator);
+        msaAssertionTranslator = responseFactory.createMsaAssertionTranslator(explicitKeySignatureTrustEngine, new SignatureValidatorFactory(), dateTimeComparator);
     }
 
     @Rule
@@ -97,7 +97,7 @@ public class MatchingAssertionTranslatorTest {
 
     @Test
     public void shouldTranslateValidAssertion() {
-        TranslatedMatchingResponseBody result = (TranslatedMatchingResponseBody) msaAssertionService.translateSuccessResponse(ImmutableList.of(
+        TranslatedMatchingResponseBody result = (TranslatedMatchingResponseBody) msaAssertionTranslator.translateSuccessResponse(ImmutableList.of(
             anAssertionWith("some-pid", LEVEL_2_AUTHN_CTX).buildUnencrypted()
         ), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
         assertThat(result).isEqualTo(new TranslatedMatchingResponseBody(
@@ -110,7 +110,7 @@ public class MatchingAssertionTranslatorTest {
 
     @Test
     public void shouldAllowHigherLevelOfAssuranceThanRequested() throws Exception {
-        TranslatedMatchingResponseBody result = (TranslatedMatchingResponseBody) msaAssertionService.translateSuccessResponse(ImmutableList.of(
+        TranslatedMatchingResponseBody result = (TranslatedMatchingResponseBody) msaAssertionTranslator.translateSuccessResponse(ImmutableList.of(
             anAssertionWith("some-pid", LEVEL_2_AUTHN_CTX).buildUnencrypted()
         ), IN_RESPONSE_TO, LEVEL_1, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
         assertThat(result).isEqualTo(new TranslatedMatchingResponseBody(
@@ -126,7 +126,7 @@ public class MatchingAssertionTranslatorTest {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Exactly one assertion is expected.");
 
-        msaAssertionService.translateSuccessResponse(emptyList(), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
+        msaAssertionTranslator.translateSuccessResponse(emptyList(), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class MatchingAssertionTranslatorTest {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Exactly one assertion is expected.");
 
-        msaAssertionService.translateSuccessResponse(null, IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
+        msaAssertionTranslator.translateSuccessResponse(null, IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class MatchingAssertionTranslatorTest {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Exactly one assertion is expected.");
 
-        msaAssertionService.translateSuccessResponse(
+        msaAssertionTranslator.translateSuccessResponse(
             ImmutableList.of(
                 anAssertion().buildUnencrypted(),
                 anAssertion().buildUnencrypted()
@@ -157,7 +157,7 @@ public class MatchingAssertionTranslatorTest {
         expectedException.expect(SamlTransformationErrorException.class);
         expectedException.expectMessage("SAML Validation Specification: Message signature is not signed");
 
-        msaAssertionService.translateSuccessResponse(Collections.singletonList(
+        msaAssertionTranslator.translateSuccessResponse(Collections.singletonList(
             anAssertionWith("some-pid", LEVEL_2_AUTHN_CTX).withoutSigning().buildUnencrypted()),
             IN_RESPONSE_TO,
             LEVEL_2,
@@ -171,7 +171,7 @@ public class MatchingAssertionTranslatorTest {
         expectedException.expectMessage("SAML Validation Specification: Signature was not valid.");
 
         Credential unknownSigningCredential = new TestCredentialFactory(TEST_PUBLIC_CERT, TEST_PRIVATE_KEY).getSigningCredential();
-        msaAssertionService.translateSuccessResponse(Collections.singletonList(
+        msaAssertionTranslator.translateSuccessResponse(Collections.singletonList(
             anAssertionWith("some-pid", LEVEL_2_AUTHN_CTX)
                 .withSignature(aSignature().withSigningCredential(unknownSigningCredential).build())
                 .buildUnencrypted()),
@@ -193,7 +193,7 @@ public class MatchingAssertionTranslatorTest {
             .addAuthnStatement(authnStatement
             ).buildUnencrypted();
 
-        msaAssertionService.translateSuccessResponse(ImmutableList.of(assertion), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
+        msaAssertionTranslator.translateSuccessResponse(ImmutableList.of(assertion), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
     }
 
     @Test
@@ -211,7 +211,7 @@ public class MatchingAssertionTranslatorTest {
                 .build())
             .buildUnencrypted();
 
-        msaAssertionService.translateSuccessResponse(ImmutableList.of(assertion), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
+        msaAssertionTranslator.translateSuccessResponse(ImmutableList.of(assertion), IN_RESPONSE_TO, LEVEL_2, VERIFY_SERVICE_PROVIDER_ENTITY_ID);
     }
 
     private AssertionBuilder aSignedAssertion() {

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
@@ -60,7 +60,6 @@ import java.security.KeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.util.List;
-import java.util.Optional;
 
 import static common.uk.gov.ida.verifyserviceprovider.utils.SamlResponseHelper.createVerifiedAttribute;
 import static java.util.Arrays.asList;

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/ResponseServiceTest.java
@@ -8,10 +8,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentCaptor;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
@@ -20,6 +20,7 @@ import org.opensaml.security.credential.Credential;
 import org.opensaml.security.crypto.KeySupport;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.saml.core.domain.SamlStatusCode;
 import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
@@ -33,18 +34,19 @@ import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
-import uk.gov.ida.saml.security.EidasValidatorFactory;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.verifyserviceprovider.dto.LevelOfAssurance;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.dto.TranslatedNonMatchingResponseBody;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedResponseBody;
 import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
 import uk.gov.ida.verifyserviceprovider.services.AssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.ClassifyingAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.MatchingAssertionTranslator;
 import uk.gov.ida.verifyserviceprovider.services.ResponseService;
+import uk.gov.ida.verifyserviceprovider.services.UnsignedAssertionsResponseHandler;
 import uk.gov.ida.verifyserviceprovider.utils.DateTimeComparator;
 import uk.gov.ida.verifyserviceprovider.validators.AssertionValidator;
 import uk.gov.ida.verifyserviceprovider.validators.ConditionsValidator;
@@ -63,6 +65,7 @@ import static common.uk.gov.ida.verifyserviceprovider.utils.SamlResponseHelper.c
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -97,13 +100,13 @@ import static uk.gov.ida.verifyserviceprovider.dto.MatchingScenario.SUCCESS_MATC
 public class ResponseServiceTest {
 
     private static final String VERIFY_SERVICE_PROVIDER_ENTITY_ID = "some-entity-id";
-    private static final String VERIFY_HUB_ENTITY_ID = "some-entity-id-for-hub";
 
     private ResponseService matchingResponseService;
     private ResponseService eidasNonMatchingResponseService;
 
     private XmlObjectToBase64EncodedStringTransformer<XMLObject> responseToBase64StringTransformer = new XmlObjectToBase64EncodedStringTransformer<>();
-    private EidasValidatorFactory mockEidasValidatorFactory = mock(EidasValidatorFactory.class);
+    private UnsignedAssertionsResponseHandler mockUnsignedAssertionsResponseHandler = mock(UnsignedAssertionsResponseHandler.class);
+    private AssertionTranslator mockAssertionTranslator = mock(ClassifyingAssertionTranslator.class);
 
     private MetadataResolver hubMetadataResolver;
 
@@ -123,7 +126,7 @@ public class ResponseServiceTest {
 
         hubMetadataResolver = mock(MetadataResolver.class);
 
-        ResponseFactory responseFactory = new ResponseFactory(keyPairs, VERIFY_HUB_ENTITY_ID);
+        ResponseFactory responseFactory = new ResponseFactory(keyPairs);
         DateTimeComparator dateTimeComparator = new DateTimeComparator(Duration.standardSeconds(5));
         TimeRestrictionValidator timeRestrictionValidator = new TimeRestrictionValidator(dateTimeComparator);
 
@@ -143,14 +146,13 @@ public class ResponseServiceTest {
             dateTimeComparator
         );
 
-        AssertionTranslator mockAssertionTranslator = mock(ClassifyingAssertionTranslator.class);
-        Optional<EidasValidatorFactory> eidasValidatorFactory = Optional.of(mockEidasValidatorFactory);
+        Optional<UnsignedAssertionsResponseHandler> unsignedAssertionsResponseHandler = Optional.of(mockUnsignedAssertionsResponseHandler);
 
         eidasNonMatchingResponseService = responseFactory.createNonMatchingResponseService(
                 signatureTrustEngine,
                 mockAssertionTranslator,
                 dateTimeComparator,
-                eidasValidatorFactory
+                unsignedAssertionsResponseHandler
         );
     }
 
@@ -185,7 +187,7 @@ public class ResponseServiceTest {
     }
 
     @Test
-    public void matchingResponseServiceshouldHandleAccountCreationSaml() throws Exception {
+    public void matchingResponseServiceShouldHandleAccountCreationSaml() throws Exception {
         EntityDescriptor entityDescriptor = createEntityDescriptorWithSigningCertificate(TEST_RP_PUBLIC_SIGNING_CERT);
         when(hubMetadataResolver.resolve(any())).thenReturn(ImmutableList.of(entityDescriptor));
 
@@ -203,6 +205,36 @@ public class ResponseServiceTest {
 
         assertThat(result.getScenario()).isEqualTo(ACCOUNT_CREATION);
         assertThat(result.getAttributes()).isNotNull();
+    }
+
+    @Test
+    public void nonMatchingResponseServiceShouldHandleUnsignedAssertions() throws Exception {
+        EntityDescriptor entityDescriptor = createEntityDescriptorWithSigningCertificate(TEST_RP_PUBLIC_SIGNING_CERT);
+        when(hubMetadataResolver.resolve(any())).thenReturn(ImmutableList.of(entityDescriptor));
+
+        Response response = signResponse(createUnsignedAttributeResponseBuilder(), testRpSigningCredential);
+        ValidatedResponse validatedResponse = new ValidatedResponse(response);
+        List<Assertion> decryptedAssertion = asList(mock(Assertion.class));
+        TranslatedNonMatchingResponseBody expectedResponse = mock(TranslatedNonMatchingResponseBody.class);
+
+        when(mockUnsignedAssertionsResponseHandler.getValidatedResponse(any(), eq(validatedResponse.getInResponseTo())))
+                .thenReturn(validatedResponse);
+        when(mockUnsignedAssertionsResponseHandler.decryptAssertion(eq(validatedResponse), any()))
+                .thenReturn(decryptedAssertion);
+        when(mockAssertionTranslator.translateSuccessResponse(eq(decryptedAssertion), eq(validatedResponse.getInResponseTo()), any(), any()))
+                .thenReturn(expectedResponse);
+
+        TranslatedNonMatchingResponseBody result = (TranslatedNonMatchingResponseBody) eidasNonMatchingResponseService.convertTranslatedResponseBody(
+                responseToBase64StringTransformer.apply(response),
+                response.getInResponseTo(),
+                LevelOfAssurance.LEVEL_2,
+                VERIFY_SERVICE_PROVIDER_ENTITY_ID
+        );
+
+        verify(mockUnsignedAssertionsResponseHandler).getValidatedResponse(any(), eq(response.getInResponseTo()));
+        verify(mockUnsignedAssertionsResponseHandler).decryptAssertion(eq(validatedResponse), any());
+
+        assertThat(result).isEqualTo(expectedResponse);
     }
 
     @Test
@@ -451,29 +483,6 @@ public class ResponseServiceTest {
         );
     }
 
-    @Test
-    public void shouldUseEidasValidatorFactoryIfResponseSignedByCountry() throws MarshallingException, SignatureException {
-        Credential testRpSigningCredential = new TestCredentialFactory(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY).getSigningCredential();
-
-        Status successStatus = aStatus().
-                withStatusCode(aStatusCode().withValue(StatusCode.SUCCESS).build())
-                .build();
-        Response response = signResponse(createNoAttributeResponseBuilder(successStatus), testRpSigningCredential);
-
-        when(mockEidasValidatorFactory.getValidatedResponse(any())).thenReturn(new ValidatedResponse(response));
-
-        eidasNonMatchingResponseService.convertTranslatedResponseBody(
-                responseToBase64StringTransformer.apply(response),
-                response.getInResponseTo(),
-                LevelOfAssurance.LEVEL_2,
-                VERIFY_SERVICE_PROVIDER_ENTITY_ID
-        );
-
-        ArgumentCaptor<Response> responseArgumentCaptor = ArgumentCaptor.forClass(Response.class);
-        verify(mockEidasValidatorFactory).getValidatedResponse(responseArgumentCaptor.capture());
-        assertThat(response.getID()).isEqualTo(responseArgumentCaptor.getValue().getID());
-    }
-
     private EntityDescriptor createEntityDescriptorWithSigningCertificate(String signingCert) throws MarshallingException, SignatureException {
         return anEntityDescriptor()
             .addSpServiceDescriptor(anSpServiceDescriptor()
@@ -513,6 +522,26 @@ public class ResponseServiceTest {
                         .build())
                 .buildWithEncrypterCredential(encryptionCredentialFactory.getEncryptingCredential())
             );
+    }
+
+    private ResponseBuilder createUnsignedAttributeResponseBuilder() {
+        return aResponse()
+                .withStatus(
+                        aStatus().
+                                withStatusCode(aStatusCode().withValue(StatusCode.SUCCESS).build())
+                                .build())
+                .withNoDefaultAssertion()
+                .addEncryptedAssertion(aDefaultAssertion()
+                        .addAttributeStatement(
+                                anAttributeStatement()
+                                        .addAttribute(new SimpleStringAttributeBuilder()
+                                                .withName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME)
+                                                .withSimpleStringValue("eidasSaml")
+                                                .build())
+                                        .build())
+                        .buildWithEncrypterCredential(encryptionCredentialFactory.getEncryptingCredential())
+                );
+
     }
 
     private AssertionBuilder aDefaultAssertion() {

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionResponseHandlerTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionResponseHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.ida.saml.core.extensions.eidas.impl.EncryptedAssertionKeysBuilder;
 import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.EidasValidatorFactory;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
 import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
@@ -48,19 +49,22 @@ import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
 public class UnsignedAssertionResponseHandlerTest {
 
     @Mock
-    EidasValidatorFactory eidasValidatorFactory;
+    private EidasValidatorFactory eidasValidatorFactory;
 
     @Mock
-    StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer;
+    private StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer;
 
     @Mock
-    InstantValidator instantValidator;
+    private InstantValidator instantValidator;
 
     @Mock
-    SecretKeyDecryptorFactory secretKeyDecryptorFactory;
+    private SecretKeyDecryptorFactory secretKeyDecryptorFactory;
 
     @Mock
-    Decrypter decrypter;
+    private Decrypter decrypter;
+
+    @Mock
+    private SamlAssertionsSignatureValidator hubAssertionSignatureValidator;
 
     private UnsignedAssertionsResponseHandler handler;
     private final List<String> singleKeyList = Arrays.asList("aKey");

--- a/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionResponseHandlerTest.java
+++ b/src/test/java/unit/uk/gov/ida/verifyserviceprovider/services/UnsignedAssertionResponseHandlerTest.java
@@ -1,0 +1,233 @@
+package unit.uk.gov.ida.verifyserviceprovider.services;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CountrySamlResponseBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.EncryptedAssertionKeysBuilder;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.security.EidasValidatorFactory;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
+import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
+import uk.gov.ida.verifyserviceprovider.services.UnsignedAssertionsResponseHandler;
+import uk.gov.ida.verifyserviceprovider.validators.InstantValidator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anEidasAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnsignedAssertionResponseHandlerTest {
+
+    @Mock
+    EidasValidatorFactory eidasValidatorFactory;
+
+    @Mock
+    StringToOpenSamlObjectTransformer<Response> stringToResponseTransformer;
+
+    @Mock
+    InstantValidator instantValidator;
+
+    @Mock
+    SecretKeyDecryptorFactory secretKeyDecryptorFactory;
+
+    @Mock
+    Decrypter decrypter;
+
+    private UnsignedAssertionsResponseHandler handler;
+    private final List<String> singleKeyList = Arrays.asList("aKey");
+    private final String samlString = "eidasSaml";
+    private final String inResponseTo = "inResponseTo";
+    private ValidatedResponse validatedResponse;
+    private Response eidasResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        IdaSamlBootstrap.bootstrap();
+
+        handler = new UnsignedAssertionsResponseHandler(
+                eidasValidatorFactory,
+                stringToResponseTransformer,
+                instantValidator,
+                secretKeyDecryptorFactory,
+                getEncryptionAlgorithmValidator()
+        );
+        eidasResponse = createEidasResponse();
+        validatedResponse = new ValidatedResponse(eidasResponse);
+    }
+
+    @Test
+    public void getValidatedResponseShouldValidateResponse() throws Exception {
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(singleKeyList);
+
+        when(stringToResponseTransformer.apply(samlString)).thenReturn(eidasResponse);
+        when(eidasValidatorFactory.getValidatedResponse(eidasResponse)).thenReturn(validatedResponse);
+
+        handler.getValidatedResponse(eidasSamlAssertion, inResponseTo);
+
+        verify(stringToResponseTransformer).apply(samlString);
+        verify(eidasValidatorFactory).getValidatedResponse(eidasResponse);
+        verify(instantValidator).validate(validatedResponse.getIssueInstant(), "Response IssueInstant");
+    }
+
+    @Test
+    public void getValidatedResponseShouldThrowIfInResponseToIsNotExpected() throws Exception {
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(singleKeyList);
+
+        when(stringToResponseTransformer.apply(samlString)).thenReturn(eidasResponse);
+        when(eidasValidatorFactory.getValidatedResponse(eidasResponse)).thenReturn(validatedResponse);
+
+        assertThrows(SamlResponseValidationException.class, () -> {
+            handler.getValidatedResponse(eidasSamlAssertion, "thisIsNotTheResponseIdYouAreLookingFor");
+        });
+    }
+
+    @Test
+    public void decryptAssertionShouldDecryptWithCorrectKey() throws Exception {
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(singleKeyList);
+        Assertion expectedAssertion = anEidasAssertion().buildUnencrypted();
+
+        when(secretKeyDecryptorFactory.createDecrypter(singleKeyList.get(0))).thenReturn(decrypter);
+        when(decrypter.decrypt(any(EncryptedAssertion.class))).thenReturn(expectedAssertion);
+        List<Assertion> assertions = handler.decryptAssertion(validatedResponse, eidasSamlAssertion);
+
+        assertThat(assertions.size()).isEqualTo(1);
+        assertThat(assertions.get(0)).isEqualTo(expectedAssertion);
+    }
+
+    @Test
+    public void decryptAssertionShouldTryMultipleKeys() throws Exception {
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(Arrays.asList("wrongKey", "anotherWrongKey", "theCorretKey"));
+        Assertion expectedAssertion = anEidasAssertion().buildUnencrypted();
+
+        when(secretKeyDecryptorFactory.createDecrypter("theCorretKey")).thenReturn(decrypter);
+        when(decrypter.decrypt(any(EncryptedAssertion.class))).thenReturn(expectedAssertion);
+        List<Assertion> assertions = handler.decryptAssertion(validatedResponse, eidasSamlAssertion);
+
+        verify(secretKeyDecryptorFactory, times(3)).createDecrypter(any());
+
+        assertThat(assertions.size()).isEqualTo(1);
+        assertThat(assertions.get(0)).isEqualTo(expectedAssertion);
+    }
+
+    @Test
+    public void decryptAssertionShouldThrowIfNoKeysCanDecrypt() throws Exception {
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(Arrays.asList("wrongKey", "anotherWrongKey", "ohNo!"));
+
+        assertThrows(SamlFailedToDecryptException.class, () -> {
+            handler.decryptAssertion(validatedResponse, eidasSamlAssertion);
+        });
+
+        verify(secretKeyDecryptorFactory, times(3)).createDecrypter(any());
+    }
+
+    @Test
+    public void decryptAssertionShouldThrowIfWrongEncryptionAlgorithmUsed() throws Exception {
+        handler = new UnsignedAssertionsResponseHandler(
+                eidasValidatorFactory,
+                stringToResponseTransformer,
+                instantValidator,
+                secretKeyDecryptorFactory,
+                new EncryptionAlgorithmValidator(
+                        ImmutableSet.of(
+                                EncryptionConstants.ALGO_ID_BLOCKCIPHER_TRIPLEDES
+                        ),
+                        ImmutableSet.of(
+                                EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP
+                        )
+                )
+        );
+        Assertion eidasSamlAssertion = anEidasSamlAssertion(singleKeyList);
+
+        assertThrows(SamlFailedToDecryptException.class, () -> {
+            handler.decryptAssertion(validatedResponse, eidasSamlAssertion);
+        });
+    }
+
+    private Assertion anEidasSamlAssertion(List<String> keys) {
+        return anAssertion()
+                .addAttributeStatement(
+                        anAttributeStatement()
+                                .addAttribute(createCountrySamlResponseAttribute(samlString))
+                                .addAttribute(createEncryptedAssertionKeysAttribute(keys))
+                                .build())
+                .buildUnencrypted();
+    }
+
+    private Attribute createCountrySamlResponseAttribute(String countrySaml) {
+        CountrySamlResponse attributeValue = new CountrySamlResponseBuilder().buildObject();
+        attributeValue.setValue(countrySaml);
+
+        Attribute attribute = (Attribute) XMLObjectSupport.buildXMLObject(Attribute.DEFAULT_ELEMENT_NAME);
+        attribute.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+        attribute.setFriendlyName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.FRIENDLY_NAME);
+        attribute.setNameFormat(Attribute.URI_REFERENCE);
+
+        attribute.getAttributeValues().add(attributeValue);
+        return attribute;
+    }
+
+    private Attribute createEncryptedAssertionKeysAttribute(List<String> keys) {
+        List<EncryptedAssertionKeys> assertionKeysValues = new ArrayList<>();
+        for (String key : keys) {
+            EncryptedAssertionKeys attributeValue = new EncryptedAssertionKeysBuilder().buildObject();
+            attributeValue.setValue(key);
+            assertionKeysValues.add(attributeValue);
+        }
+
+        Attribute attribute = (Attribute) XMLObjectSupport.buildXMLObject(Attribute.DEFAULT_ELEMENT_NAME);
+        attribute.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+        attribute.setFriendlyName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.FRIENDLY_NAME);
+        attribute.setNameFormat(Attribute.URI_REFERENCE);
+
+        attribute.getAttributeValues().addAll(assertionKeysValues);
+        return attribute;
+    }
+
+    private Response createEidasResponse() throws Exception {
+        return aResponse()
+            .addEncryptedAssertion(
+                    anEidasAssertion().build())
+            .withInResponseTo(inResponseTo)
+            .build();
+    }
+
+    private EncryptionAlgorithmValidator getEncryptionAlgorithmValidator() {
+        return new EncryptionAlgorithmValidator(
+                ImmutableSet.of(
+                        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128
+                ),
+                ImmutableSet.of(
+                        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP
+                )
+        );
+    }
+}


### PR DESCRIPTION
If you want to run the VSP locally so you can debug it, there are a couple of branches which will help. These are by no means meant to be a good way to run it, it's just how I hacked it together when developing this PR. Use these branches locally and then run `./hubstartup.sh` in `ida-hub-acceptance-tests`
https://github.com/alphagov/ida-hub-acceptance-tests/tree/test-rp-vsp
https://github.com/alphagov/verify-test-rp/tree/non-matching

You'll also need to cherry pick the last commit from this branch of the VSP, which adds a local config: https://github.com/alphagov/verify-service-provider/tree/eid-1607

### EID-1607 Bump saml-lib to build 221
It includes a few updates including making it easier to create a
decrypter for unsigned assertions.

### EID-1607 Update ResponseService to use `UnsignedAssertionsResponseHandler`
The ResponseService needs to be able to determine if the incoming
Response has unsigned assertions wrapped up inside it. We do this with a
private helper method which interrogates the names of the attribute
values within the assertion, and returns false if any match the Constant
defined for this purpose, which will have been set by the hub.

If it determines that the assertion _does_ contain eIDAS unsigned
assertions it uses the new UnsignedAssertionsResponseHandler to first
validate the original eIDAS SAML response, and then if valid, decrypt
the assertions.

These assertions are then passed to the assertion translator instead of
the original wrapper assertion.

### EID-1607 Create UnsignedAssertionsResponseHandler …
This class will get called by the response service to handle the wrapper
Response that contains the original unsigned response from the country,
and the encryption keys required to decrypt the assertions it contains.

It uses the `eidasValidatorFactory` from saml-lib to validate the
original response signature.

The other interesting method `decryptAssertion` will iterate through all
the keys supplied in the wrapper Response assertion and attempt to
decrypt the assertions in the validated country response. Most of the
time we only expect to receive one key, but we do pass a list so it's
worth trying all of them.

We also pass into this a `EidasEncryptionAlgorithmValidator` which is a
new class. The eIDAS spec defines different encryption algorithms to
that which the hub uses, so we need to make sure we're validating the
country response against the right things.

### EID-1607 Add `EidasUnsignedAssertionTranslator` …
In an eIDAS enabled non-matching set up, the `assertionTranslator` used
by the `ResponseService` is a `ClassifyingAssertionTranslator`.

This translator is configured with different translators and will
determine which to use depending on the assertions given to it.

This extends it to include the new `EidasUnsignedAssertionTranslator`
which will deal with unsigned assertions.

The only difference in dealing with signed and unsigned assertions is
the validation of the signature. As such, the vast majority of the logic
in `EidasAssertionTranslator` has been moved to an abstract base class
which is extended by the new `EidasAssertionTranslator` as well as the
new one. They both just implement the abstract `validateSignature`
method.

### EID 1607 Create UnsignedAssertionsResponseHandler in VerifyServiceProviderFactory
The new `UnsignedAssertionsResponseHandler` only needs creating if the
VSP is configured to run as an eIDAS enabled non-matching VSP. As such,
we create the new response handler in the relevant method of the
`VerifyServiceProviderFactory`.

We also create the `EidasUnsignedAssertionTranslator` here which is
required by the `ClassifyingAssertionTranslator`.

### EID-1607 Create `createEidasUnsignedAssertionService` in ResponseFactory
This allows us to create a new `EidasUnsignedAssertionTranslator`, and
is called from the `VerifyServiceProviderFactory`. It's a similar
pattern to how the `EidasAssertionTranslator` is created.

Also tidy up some tests.

### EID-1607 Add an acceptance test for unsigned assertions
This test creates an eIDAS Response with an unsigned encrypted
assertion. It then converts that Response into a string and stuffs it
into a hub Response.

The hub Response has two attributes in its assertion. One is the
original eIDAS response, the other is the encryption keys used in that
response, which have been extracted and encrypted for the RP.

The encryption algorithm used in the eIDAS response has been changed to
be one of the eIDAS spec algorithms.

### EID-1607 Validate hub assertion signature
If we're dealing with unsigned assertions, the assertion containing the
original eIDAS SAML and encrypted assertion keys will be signed by the
hub. We should validate that signature.