### PR TITLE
BAU: Include local binaries in docker workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
 .gradle
-build
+*/build/*
+!*/build/install/
 logs


### PR DESCRIPTION
This is so we can build local docker images of the VSP using binaries built locally instead of building them in docker every time

This is needed for the Proxy Node local startup to work