### PR TITLE
BAU: Revert including local binaries in docker workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .git
 .gradle
-*/build/*
-!*/build/install/
+build/
+*/build/
 logs


### PR DESCRIPTION
This used to be so we could build local docker images of the VSP using binaries built locally instead of building them in docker every time.

This used to be needed for the Proxy Node local startup to work but now we mount the bins so they don't need to be included in Docker context. This makes docker build run faster.

This is the result of alphagov/verify-proxy-node#583