### PR TITLE
Test errors for incorrectly crafted translation requests

### DIFF
--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/AuthnRequestAcceptanceTest.java
@@ -8,6 +8,7 @@ import keystore.KeyStoreResource;
 import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.platform.commons.util.StringUtils;
 import uk.gov.ida.verifyserviceprovider.configuration.VerifyServiceProviderConfiguration;
 import uk.gov.ida.verifyserviceprovider.dto.RequestGenerationBody;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
@@ -87,13 +88,14 @@ public class AuthnRequestAcceptanceTest {
 
         setupComplianceToolWithDefaultEntityId(client);
 
-        Response authnResponse = client
+        Response generateRequestResponse = client
                 .target(URI.create(String.format("http://localhost:%d/generate-request", singleTenantApplication.getLocalPort())))
                 .request()
                 .buildPost(Entity.json(null))
                 .invoke();
 
-        RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
+        RequestResponseBody authnSaml = generateRequestResponse.readEntity(RequestResponseBody.class);
+        assertThat(StringUtils.isNotBlank(authnSaml.getRequestId()));
 
         Response complianceToolResponse = client
                 .target(authnSaml.getSsoLocation())
@@ -120,6 +122,7 @@ public class AuthnRequestAcceptanceTest {
             .invoke();
 
         RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
+        assertThat(StringUtils.isNotBlank(authnSaml.getRequestId()));
 
         Response complianceToolResponse = client
             .target(authnSaml.getSsoLocation())
@@ -145,6 +148,7 @@ public class AuthnRequestAcceptanceTest {
             .invoke();
 
         RequestResponseBody authnSaml = authnResponse.readEntity(RequestResponseBody.class);
+        assertThat(StringUtils.isNotBlank(authnSaml.getRequestId()));
 
         Response complianceToolResponse = client
             .target(authnSaml.getSsoLocation())

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
@@ -180,7 +180,7 @@ public class SuccessMatchAcceptanceTest {
     public void shouldReturnAnErrorWhenNullRequestIdIsProvided() {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
 
-        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        Map<String, String> translateResponseRequestData = new HashMap<>();
         translateResponseRequestData.put(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
         translateResponseRequestData.put("requestId", null);
@@ -202,7 +202,7 @@ public class SuccessMatchAcceptanceTest {
     public void shouldReturnAnErrorForTheNullRequestIdProvidedRegardlessOfIncorrectSaml() {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
 
-        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        Map<String, String> translateResponseRequestData = new HashMap<>();
         translateResponseRequestData.put("samlResponse", "not a SAML response");
         translateResponseRequestData.put("requestId", null);
         translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
@@ -275,7 +275,7 @@ public class SuccessMatchAcceptanceTest {
     public void shouldReturnAnErrorWhenAnEmptyRequestIdIsProvided() {
         RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
 
-        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        Map<String, String> translateResponseRequestData = new HashMap<>();
         translateResponseRequestData.put(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
         translateResponseRequestData.put("requestId", "");
@@ -300,7 +300,7 @@ public class SuccessMatchAcceptanceTest {
 
         String falseRequestId = "_" + UUID.randomUUID().toString();
 
-        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        Map<String, String> translateResponseRequestData = new HashMap<>();
         translateResponseRequestData.put(
             "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
         translateResponseRequestData.put("requestId", falseRequestId);

--- a/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
+++ b/src/acceptance-test/java/uk/gov/ida/verifyserviceprovider/SuccessMatchAcceptanceTest.java
@@ -7,15 +7,20 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.verifyserviceprovider.dto.RequestResponseBody;
 import uk.gov.ida.verifyserviceprovider.dto.TranslatedMatchingResponseBody;
+import uk.gov.ida.verifyserviceprovider.factories.saml.ResponseFactory;
 import uk.gov.ida.verifyserviceprovider.rules.VerifyServiceProviderAppRule;
 import uk.gov.ida.verifyserviceprovider.services.ComplianceToolService;
 import uk.gov.ida.verifyserviceprovider.services.GenerateRequestService;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -169,5 +174,148 @@ public class SuccessMatchAcceptanceTest {
         ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
         assertThat(errorMessage.getCode()).isEqualTo(BAD_REQUEST.getStatusCode());
         assertThat(errorMessage.getMessage()).isEqualTo("Provided entityId: invalidEntityId is not listed in config");
+    }
+
+    @Test
+    public void shouldReturnAnErrorWhenNullRequestIdIsProvided() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        translateResponseRequestData.put(
+            "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
+        translateResponseRequestData.put("requestId", null);
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(422);
+        assertThat(errorMessage.getMessage()).isEqualTo("requestId may not be null");
+    }
+
+    @Test
+    public void shouldReturnAnErrorForTheNullRequestIdProvidedRegardlessOfIncorrectSaml() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        translateResponseRequestData.put("samlResponse", "not a SAML response");
+        translateResponseRequestData.put("requestId", null);
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(422);
+        assertThat(errorMessage.getMessage()).isEqualTo("requestId may not be null");
+    }
+
+    @Test
+    public void shouldReturnAnErrorForAlteredSamlResponses() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        String saml = complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID);
+
+        StringToOpenSamlObjectTransformer<org.opensaml.saml.saml2.core.Response> deserializer = ResponseFactory.createStringToResponseTransformer();
+        org.opensaml.saml.saml2.core.Response authenticationResponse = deserializer.apply(saml);
+        authenticationResponse.setInResponseTo(null);
+
+        XmlObjectToBase64EncodedStringTransformer<org.opensaml.saml.saml2.core.Response> reserializer = new XmlObjectToBase64EncodedStringTransformer<>();
+        String alteredEncodedSaml = reserializer.apply(authenticationResponse);
+
+        Map<String, String> translateResponseRequestData = new HashMap<>();
+        translateResponseRequestData.put("samlResponse", alteredEncodedSaml);
+        translateResponseRequestData.put("requestId", requestResponseBody.getRequestId());
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(BAD_REQUEST.getStatusCode());
+        assertThat(errorMessage.getMessage()).isEqualTo("SAML Validation Specification: Message signature is not signed\n" +
+            "DocumentReference{documentName='Hub Service Profile 1.1a', documentSection=''}");
+    }
+
+    @Test
+    public void shouldReturnAnErrorForNonSamlResponses() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        Map<String, String> translateResponseRequestData = new HashMap<>();
+        translateResponseRequestData.put("samlResponse", "not a SAML response");
+        translateResponseRequestData.put("requestId", requestResponseBody.getRequestId());
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(BAD_REQUEST.getStatusCode());
+        assertThat(errorMessage.getMessage()).startsWith("SAML Validation Specification: Unable to deserialize string into OpenSaml object");
+    }
+
+    @Test
+    public void shouldReturnAnErrorWhenAnEmptyRequestIdIsProvided() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        translateResponseRequestData.put(
+            "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
+        translateResponseRequestData.put("requestId", "");
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(BAD_REQUEST.getStatusCode());
+        assertThat(errorMessage.getMessage()).isEqualTo(
+            String.format("Expected InResponseTo to be %s, but was %s", "", requestResponseBody.getRequestId()));
+    }
+
+    @Test
+    public void shouldReturnAnErrorWhenAnIncorrectRequestIdIsProvided() {
+        RequestResponseBody requestResponseBody = generateRequestService.generateAuthnRequest(application.getLocalPort());
+
+        String falseRequestId = "_" + UUID.randomUUID().toString();
+
+        Map<String, String> translateResponseRequestData = new HashMap<>(); // not a lot of map implementations allow nulls
+        translateResponseRequestData.put(
+            "samlResponse", complianceTool.createResponseFor(requestResponseBody.getSamlRequest(), BASIC_SUCCESSFUL_MATCH_WITH_LOA2_ID));
+        translateResponseRequestData.put("requestId", falseRequestId);
+        translateResponseRequestData.put("levelOfAssurance", LEVEL_2.name());
+
+        Response response = client
+            .target(String.format("http://localhost:%d/translate-response", application.getLocalPort()))
+            .request()
+            .buildPost(json(translateResponseRequestData))
+            .invoke();
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST.getStatusCode());
+        ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
+        assertThat(errorMessage.getCode()).isEqualTo(BAD_REQUEST.getStatusCode());
+        assertThat(errorMessage.getMessage()).isEqualTo(
+            String.format("Expected InResponseTo to be %s, but was %s", falseRequestId, requestResponseBody.getRequestId()));
     }
 }


### PR DESCRIPTION
* Adds a number of additional tests to `SuccessMatchAcceptanceTest` for errors that `translate-response` can generate.
* Adds some assertions to `AuthnRequestAcceptanceTest` to illustrate that the `requestId` is always generated.
