### PR TITLE
BAU: Upgrade saml-libs to 249

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@ Release notes
 =============
 
 ### Next
+* Fixes an issue with trust anchors for eIDAS metadata resolvers not being updated when they changed at source. The VSP
+  will now update them without requiring a restart.
 
 ### 2.2.0
 [View Diff](https://github.com/alphagov/verify-service-provider/compare/2.1.0...2.2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ project.ext {
     version_number = '2.2.0'
     openSamlVersion = '3.4.3'
     verifyCommonUtils = '2.0.0-374'
-    samlLibVersion = "$openSamlVersion-246"
+    samlLibVersion = "$openSamlVersion-249"
     dropwizardVersion = '1.3.17'
     jaxbapiVersion = '2.2.9'
 }


### PR DESCRIPTION
This version includes a fix for a bug where metadata resolvers were not
picking up on changes to a countries trust-anchor.