### PR TITLE
HUB-774 Update Dockerfile to use GHCR

### DIFF
--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -1,4 +1,4 @@
-FROM gradle:6.7.0-jdk11 as build
+FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build
 ARG VERIFY_USE_PUBLIC_BINARIES=false
 WORKDIR /verify-service-provider
 USER root
@@ -13,7 +13,7 @@ RUN gradle installDist
 ENTRYPOINT ["gradle"]
 CMD ["tasks"]
 
-FROM openjdk:11.0.9.1-jre
+FROM ghcr.io/alphagov/verify/java:openjdk-11
 
 WORKDIR /verify-service-provider
 


### PR DESCRIPTION
Update the Dockerfile to use images from GitHub container registry rather than having them come from DockerHub.