### PR TITLE
HUB-914: Pull from maven central

### DIFF
--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build
+FROM gradle:6.8.3-jdk11 as build
 ARG VERIFY_USE_PUBLIC_BINARIES=false
 WORKDIR /verify-service-provider
 USER root

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@ Release notes
 
 ### Next
 * Use saml-libs release that removes eIDAS code
+* Pull dependencies for public builds from Maven Central.
+
 ### 3.0.0
 [View Diff](https://github.com/alphagov/verify-service-provider/compare/2.2.0...3.0.0)
 * Removed processing of assertions received from EU Member States. The configuration parameter `europeanIdentity`, if present, and child elements must be removed in order for the VSP to start.

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,5 @@
-plugins {
-    id 'com.github.ben-manes.versions' version '0.17.0'
-}
-
 apply plugin: 'java'
 apply plugin: 'application'
-apply plugin: 'idea'
 
 if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
     apply plugin: 'jacoco'
@@ -20,10 +15,7 @@ if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -33,8 +25,8 @@ repositories {
 project.ext {
     version_number = '3.0.0'
     openSamlVersion = '3.4.3'
-    verifyCommonUtils = '2.0.0-374'
-    samlLibVersion = "$openSamlVersion-250"
+    verifyCommonUtils = '2.0.0-396'
+    samlLibVersion = "$openSamlVersion-255"
     dropwizardVersion = '1.3.17'
     jaxbapiVersion = '2.2.9'
 }
@@ -47,8 +39,8 @@ dependencies {
         "org.opensaml:opensaml-core:$openSamlVersion",
         "org.opensaml:opensaml-saml-impl:$openSamlVersion",
         "uk.gov.ida:common-utils:$verifyCommonUtils",
-        "uk.gov.ida:dropwizard-logstash:$dropwizardVersion-79",
-        "uk.gov.ida:rest-utils:2.0.0-370",
+        "uk.gov.ida:dropwizard-logstash:1.3.22-89",
+        "uk.gov.ida:rest-utils:$verifyCommonUtils",
         "uk.gov.ida:saml-lib:$samlLibVersion",
         "org.bouncycastle:bcprov-jdk15on:1.60",
         "org.bouncycastle:bcpkix-jdk15on:1.60",
@@ -60,7 +52,7 @@ dependencies {
         "org.junit.jupiter:junit-jupiter-api:5.5.2",
         "io.dropwizard:dropwizard-testing:$dropwizardVersion",
         'org.mockito:mockito-core:3.2.0',
-        "uk.gov.ida:common-test-utils:2.0.0-49",
+        "uk.gov.ida:common-test-utils:2.0.0-65",
         "org.jsoup:jsoup:1.11.1",
         "uk.gov.ida:saml-test:$samlLibVersion",
         "javax.activation:javax.activation-api:1.2.0",
@@ -110,6 +102,10 @@ sourceSets {
             srcDir 'src/test/resources'
         }
     }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileJava {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -3,5 +3,3 @@ set -e
 
 cd "$(dirname "$0")"
 ./gradlew clean test testAcceptance
-./gradlew dependencyUpdates
-


### PR DESCRIPTION
Remove unloved versions plugin.

Remove unused idea plugin.

Update dockerfile to use a base image with version 6.8.3. The vendored
image has slipped to version 7 which doesn't work.

Update public builds to use maven central and bump versions of
dependencies to ensure the maven central artifacts are being used.

Update gradle to 6.8.3