### PR TITLE
[HUB-841] Update dockerfiles to use dockerhub again.

### DIFF
--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -17,7 +17,7 @@ FROM openjdk:11.0.9.1-jre
 WORKDIR /verify-service-provider
 
 COPY verify-service-provider.yml verify-service-provider.yml
-COPY --from=build home/gradle/verify-service-provider/build/install/verify-service-provider .
+COPY --from=build /home/gradle/verify-service-provider/build/install/verify-service-provider .
 
 ENTRYPOINT ["sh", "-c"]
 CMD ["bin/verify-service-provider", "server", "verify-service-provider.yml"]

--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -1,24 +1,23 @@
 FROM gradle:6.8.3-jdk11 as build
 ARG VERIFY_USE_PUBLIC_BINARIES=false
-WORKDIR /verify-service-provider
-USER root
+USER gradle
+RUN mkdir /home/gradle/verify-service-provider \
+ && chown --recursive gradle:gradle /home/gradle/verify-service-provider
+WORKDIR /home/gradle/verify-service-provider
 ENV GRADLE_USER_HOME ~/.gradle
 
-COPY build.gradle build.gradle
-COPY settings.gradle settings.gradle
-COPY src src
-
+COPY --chown=gradle:gradle build.gradle settings.gradle src ./
 RUN gradle installDist
 
 ENTRYPOINT ["gradle"]
 CMD ["tasks"]
 
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM openjdk:11.0.9.1-jre
 
 WORKDIR /verify-service-provider
 
 COPY verify-service-provider.yml verify-service-provider.yml
-COPY --from=build /verify-service-provider/build/install/verify-service-provider .
+COPY --from=build home/gradle/verify-service-provider/build/install/verify-service-provider .
 
 ENTRYPOINT ["sh", "-c"]
 CMD ["bin/verify-service-provider", "server", "verify-service-provider.yml"]

--- a/startup.sh
+++ b/startup.sh
@@ -8,13 +8,15 @@ case $1 in
         CONFIG_FILE=./local-running/local-config.yml
         if test -e local.env; then
             set -a
+            # shellcheck disable=SC1091
             source local.env
             set +a
         else
-            printf "$(tput setaf 1)No local environment found. Use verify-local-startup or openssl to generate a local.env file\n$(tput sgr0)"
+            printf "%sNo local environment found. Use verify-local-startup or openssl to generate a local.env file\n%s" "$(tput setaf  1)" "$(tput sgr0)"
         fi
         ;;
     'vsp-only')
+        # shellcheck disable=SC1091
         source ./local-running/local-vsp-only.env
         ;;
 esac


### PR DESCRIPTION
The decision was made to use a paid Docker Hub account in the pipeline rather than GitHub packages after the move previously to github packages when Docker Hub imposed rate limit restrictions.

- Removed `USER root` and swapped to using `USER gradle`. The [base image](https://github.com/keeganwitt/docker-gradle/blob/019489a1187aac1788f5369048c34969462a0456/hotspot/jdk11/Dockerfile) creates a user called gradle but never swaps to it. It symlinks root cache too. We shouldn't in theory have any reason to use root with this container, granted it's only a building layer but personally I think it's better to use non-root. Given `WORKDIR` doesn't let you clarify which user to create the folder with I've had to create the folder first and `chown` it. Likewise with the `COPY` commands which also require `--chown gradle:gradle` flags.
- Consensed `COPY` commands into a single line
- Ran `*.sh` scripts against shellcheck and corrected issues raised.
- Moved instruction to pull from ghcr.io/alphagov/verify/java:openjdk-11 in-line with the previous commit https://github.com/alphagov/verify-service-provider/commit/57498af6b97f6d38343ed8dedd10d4580bba52f5