### PR TITLE
Update RELEASE_NOTES and build.gradle for release 3.0.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@ Release notes
 =============
 
 ### Next
+
+### 3.0.1
+[View Diff](https://github.com/alphagov/verify-service-provider/compare/3.0.0...3.0.1)
 * Use saml-libs release that removes eIDAS code
 * Pull dependencies for public builds from Maven Central.
 * Update logback library to version 1.2.9

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 project.ext {
-    version_number = '3.0.0'
+    version_number = '3.0.1'
     openSamlVersion = '3.4.3'
     verifyCommonUtils = '2.0.0-396'
     samlLibVersion = "$openSamlVersion-255"


### PR DESCRIPTION
Pull Request to bump the VSP from 3.0.0 to 3.0.1.

Followed guidance at https://verify-team-manual.cloudapps.digital/support/vsp-release/#releasing-the-vsp