### PR TITLE
BAU - Force version of xmlsec to 2.1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ configurations.all {
     resolutionStrategy {
         force "ch.qos.logback:logback-classic:1.2.9"
         force "ch.qos.logback:logback-access:1.2.9"
+        force "org.apache.santuario:xmlsec:2.1.8"
     }
 }
 


### PR DESCRIPTION
- xmlsec and commons-collections are both brought in by opensaml. We want to override the version brought in my opensaml.